### PR TITLE
BIP-68 (LOCKTIME_VERIFY_SEQUENCE) from genesis

### DIFF
--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -34,8 +34,6 @@ static const int COINBASE_MATURITY = 100;
 static const int MAX_COINBASE_SCRIPTSIG_SIZE = 100;
 
 /** Flags for nSequence and nLockTime locks */
-/** Interpret sequence numbers as relative lock-time constraints. */
-static constexpr unsigned int LOCKTIME_VERIFY_SEQUENCE = (1 << 0);
 /** Use GetMedianTimePast() instead of nTime for end point timestamp. */
 static constexpr unsigned int LOCKTIME_MEDIAN_TIME_PAST = (1 << 1);
 

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -83,8 +83,7 @@ std::pair<int, int64_t> CalculateSequenceLocks(const CTransaction &tx,
     // tx.nVersion is signed integer so requires cast to unsigned otherwise
     // we would be doing a signed comparison and half the range of nVersion
     // wouldn't support BIP 68.
-    bool fEnforceBIP68 = static_cast<uint32_t>(tx.nVersion) >= 2 &&
-                         flags & LOCKTIME_VERIFY_SEQUENCE;
+    bool fEnforceBIP68 = static_cast<uint32_t>(tx.nVersion) >= 2;
 
     // Do not enforce sequence numbers as a relative lock time
     // unless we have been instructed to

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -102,7 +102,7 @@ static constexpr uint32_t STANDARD_NOT_MANDATORY_VERIFY_FLAGS =
  * code.
  */
 static constexpr uint32_t STANDARD_LOCKTIME_VERIFY_FLAGS =
-    LOCKTIME_VERIFY_SEQUENCE | LOCKTIME_MEDIAN_TIME_PAST;
+    LOCKTIME_MEDIAN_TIME_PAST;
 
 Amount GetDustThreshold(const CTxOut &txout, const CFeeRate &dustRelayFee);
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1773,9 +1773,6 @@ bool CChainState::ConnectBlock(const CBlock &block, BlockValidationState &state,
 
     // Start enforcing BIP68 (sequence locks).
     int nLockTimeFlags = 0;
-    if (pindex->nHeight >= consensusParams.CSVHeight) {
-        nLockTimeFlags |= LOCKTIME_VERIFY_SEQUENCE;
-    }
 
     const uint32_t flags =
         GetNextBlockScriptFlags(consensusParams, pindex->pprev);

--- a/test/functional/feature_bip68_sequence.py
+++ b/test/functional/feature_bip68_sequence.py
@@ -78,8 +78,8 @@ class BIP68Test(BitcoinTestFramework):
         self.test_sequence_lock_unconfirmed_inputs()
 
         self.log.info(
-            "Running test BIP68 not consensus before versionbits activation")
-        self.test_bip68_not_consensus()
+            "Make sure BIP-68 txs always work, independent of when they are activated on Bitcoin.")
+        self.test_version2_relay()
 
         self.log.info("Activating BIP68 (and 112/113)")
         self.activateCSV()
@@ -418,61 +418,6 @@ class BIP68Test(BitcoinTestFramework):
     def get_csv_status(self):
         height = self.nodes[0].getblockchaininfo()['blocks']
         return height >= 576
-
-    # Make sure that BIP68 isn't being used to validate blocks, prior to
-    # versionbits activation.  If more blocks are mined prior to this test
-    # being run, then it's possible the test has activated the soft fork, and
-    # this test should be moved to run earlier, or deleted.
-    def test_bip68_not_consensus(self):
-        assert_equal(self.get_csv_status(), False)
-        txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 2)
-
-        tx1 = FromHex(CTransaction(), self.nodes[0].getrawtransaction(txid))
-        tx1.rehash()
-
-        # Make an anyone-can-spend transaction
-        tx2 = CTransaction()
-        tx2.nVersion = 1
-        tx2.vin = [CTxIn(COutPoint(tx1.sha256, 0), nSequence=0)]
-        tx2.vout = [
-            CTxOut(int(tx1.vout[0].nValue - self.relayfee * COIN), CScript([b'a']))]
-
-        # sign tx2
-        tx2_raw = self.nodes[0].signrawtransactionwithwallet(ToHex(tx2))["hex"]
-        tx2 = FromHex(tx2, tx2_raw)
-        pad_tx(tx2)
-        tx2.rehash()
-
-        self.nodes[0].sendrawtransaction(ToHex(tx2))
-
-        # Now make an invalid spend of tx2 according to BIP68
-        # 100 block relative locktime
-        sequence_value = 100
-
-        tx3 = CTransaction()
-        tx3.nVersion = 2
-        tx3.vin = [CTxIn(COutPoint(tx2.sha256, 0), nSequence=sequence_value)]
-        tx3.vout = [
-            CTxOut(int(tx2.vout[0].nValue - self.relayfee * COIN), CScript([b'a']))]
-        pad_tx(tx3)
-        tx3.rehash()
-
-        assert_raises_rpc_error(-26, NOT_FINAL_ERROR,
-                                self.nodes[0].sendrawtransaction, ToHex(tx3))
-
-        # make a block that violates bip68; ensure that the tip updates
-        tip = int(self.nodes[0].getbestblockhash(), 16)
-        block = create_block(
-            tip, create_coinbase(self.nodes[0].getblockcount() + 1))
-        block.nVersion = 3
-        block.vtx.extend(
-            sorted([tx1, tx2, tx3], key=lambda tx: tx.get_id()))
-        block.hashMerkleRoot = block.calc_merkle_root()
-        block.rehash()
-        block.solve()
-
-        assert_equal(None, self.nodes[0].submitblock(ToHex(block)))
-        assert_equal(self.nodes[0].getbestblockhash(), block.hash)
 
     def activateCSV(self):
         # activation should happen at block height 576

--- a/test/functional/feature_csv_activation.py
+++ b/test/functional/feature_csv_activation.py
@@ -434,6 +434,10 @@ class BIP68_112_113Test(BitcoinTestFramework):
             bip112tx_special_v2,
             spend_tx(self.nodes[0], bip112tx_special_v2, self.nodeaddress),
         ]])
+        self.send_failure_blocks([
+            [tx]
+            for tx in all_rlt_txs(bip68txs_v2[8:])
+        ])
         # add BIP 112 with seq=10 txs
         self.send_failure_blocks([
             [tx, spend_tx(self.nodes[0], tx, self.nodeaddress)]
@@ -441,7 +445,7 @@ class BIP68_112_113Test(BitcoinTestFramework):
         ])
         self.send_failure_blocks([
             [tx, spend_tx(self.nodes[0], tx, self.nodeaddress)]
-            for tx in all_rlt_txs(bip112txs_vary_OP_CSV_v2[8:])
+            for tx in all_rlt_txs(bip112txs_vary_OP_CSV_v2)
         ])
         self.send_failure_blocks([
             [tx, spend_tx(self.nodes[0], tx, self.nodeaddress)]
@@ -449,7 +453,7 @@ class BIP68_112_113Test(BitcoinTestFramework):
         ])
         self.send_failure_blocks([
             [tx, spend_tx(self.nodes[0], tx, self.nodeaddress)]
-            for tx in all_rlt_txs(bip112txs_vary_OP_CSV_9_v2[8:])
+            for tx in all_rlt_txs(bip112txs_vary_OP_CSV_9_v2)
         ])
 
         # add BIP113 tx and -1 CSV tx
@@ -459,16 +463,7 @@ class BIP68_112_113Test(BitcoinTestFramework):
         success_txs = []
         success_txs.append(bip113signed2)
         # add BIP 68 txs
-        success_txs.extend(all_rlt_txs(bip68txs_v2))
-        success_txs.extend([
-            tx
-            for setup_txs in [
-                bip112txs_vary_OP_CSV_v2[:8],
-                bip112txs_vary_OP_CSV_9_v2[:8]
-            ]
-            for setup_tx in all_rlt_txs(setup_txs)
-            for tx in [setup_tx, spend_tx(self.nodes[0], setup_tx, self.nodeaddress)]
-        ])
+        success_txs.extend(all_rlt_txs(bip68txs_v2[:8]))
         # Test #4
         self.send_blocks([self.create_test_block(success_txs)])
         self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())


### PR DESCRIPTION
- Remove `LOCKTIME_VERIFY_SEQUENCE`.
- Mitigate buggy miner_tests test by setting nSequence to valid values before adding them to the mempool.