### PR TITLE
Mtp locktime from genesis

### DIFF
--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -33,10 +33,6 @@ static const int COINBASE_MATURITY = 100;
 /** Coinbase scripts have their own script size limit. */
 static const int MAX_COINBASE_SCRIPTSIG_SIZE = 100;
 
-/** Flags for nSequence and nLockTime locks */
-/** Use GetMedianTimePast() instead of nTime for end point timestamp. */
-static constexpr unsigned int LOCKTIME_MEDIAN_TIME_PAST = (1 << 1);
-
 /**
  * Compute the maximum number of sigchecks that can be contained in a block
  * given the MAXIMUM block size as parameter. The maximum sigchecks scale

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -149,11 +149,7 @@ BlockAssembler::CreateNewBlock(const CScript &scriptPubKeyIn) {
     }
 
     pblock->nTime = GetAdjustedTime();
-    nMedianTimePast = pindexPrev->GetMedianTimePast();
-    nLockTimeCutoff =
-        (STANDARD_LOCKTIME_VERIFY_FLAGS & LOCKTIME_MEDIAN_TIME_PAST)
-            ? nMedianTimePast
-            : pblock->GetBlockTime();
+    nLockTimeCutoff = pindexPrev->GetMedianTimePast();
 
     int nPackagesSelected = 0;
     int nDescendantsUpdated = 0;

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -101,8 +101,7 @@ static constexpr uint32_t STANDARD_NOT_MANDATORY_VERIFY_FLAGS =
  * Used as the flags parameter to sequence and nLocktime checks in non-consensus
  * code.
  */
-static constexpr uint32_t STANDARD_LOCKTIME_VERIFY_FLAGS =
-    LOCKTIME_MEDIAN_TIME_PAST;
+static constexpr uint32_t STANDARD_LOCKTIME_VERIFY_FLAGS = 0;
 
 Amount GetDustThreshold(const CTxOut &txout, const CFeeRate &dustRelayFee);
 

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -490,7 +490,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity) {
 
     // non-final txs in mempool
     SetMockTime(::ChainActive().Tip()->GetMedianTimePast() + 1);
-    uint32_t flags = LOCKTIME_MEDIAN_TIME_PAST;
+    uint32_t flags = 0;
     // height map
     std::vector<int> prevheights;
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3883,9 +3883,7 @@ bool ContextualCheckTransactionForCurrentBlock(const Consensus::Params &params,
         ::ChainActive().Tip() == nullptr
             ? 0
             : ::ChainActive().Tip()->GetMedianTimePast();
-    const int64_t nLockTimeCutoff = (flags & LOCKTIME_MEDIAN_TIME_PAST)
-                                        ? nMedianTimePast
-                                        : GetAdjustedTime();
+    const int64_t nLockTimeCutoff = nMedianTimePast;
 
     return ContextualCheckTransaction(params, tx, state, nBlockHeight,
                                       nLockTimeCutoff, nMedianTimePast);
@@ -3903,20 +3901,11 @@ static bool ContextualCheckBlock(const CBlock &block,
                                  const Consensus::Params &params,
                                  const CBlockIndex *pindexPrev) {
     const int nHeight = pindexPrev == nullptr ? 0 : pindexPrev->nHeight + 1;
-
-    // Start enforcing BIP113 (Median Time Past).
-    int nLockTimeFlags = 0;
-    if (nHeight >= params.CSVHeight) {
-        assert(pindexPrev != nullptr);
-        nLockTimeFlags |= LOCKTIME_MEDIAN_TIME_PAST;
-    }
-
+    
+    // Always enforce BIP113 (Median Time Past).    
     const int64_t nMedianTimePast =
         pindexPrev == nullptr ? 0 : pindexPrev->GetMedianTimePast();
-
-    const int64_t nLockTimeCutoff = (nLockTimeFlags & LOCKTIME_MEDIAN_TIME_PAST)
-                                        ? nMedianTimePast
-                                        : block.GetBlockTime();
+    const int64_t nLockTimeCutoff = nMedianTimePast;
 
     // Check transactions:
     // - canonical ordering

--- a/test/functional/feature_csv_activation.py
+++ b/test/functional/feature_csv_activation.py
@@ -404,13 +404,12 @@ class BIP68_112_113Test(BitcoinTestFramework):
             [tx, spend_tx(self.nodes[0], tx, self.nodeaddress)]
             for tx in all_rlt_txs(bip112txs_vary_OP_CSV_9_v1[8:])
         ])
-
         # add BIP113 tx and -1 CSV tx
         # = MTP of prior block (not <) but < time put on current block
         bip113tx_v1.nLockTime = self.last_block_time - 600 * 5
         bip113signed1 = sign_transaction(self.nodes[0], bip113tx_v1)
+        self.send_failure_blocks([[bip113signed1]])
         success_txs = []
-        success_txs.append(bip113signed1)
         # add BIP 68 txs
         success_txs.extend(all_rlt_txs(bip68txs_v1))
         success_txs.extend([
@@ -455,13 +454,13 @@ class BIP68_112_113Test(BitcoinTestFramework):
             [tx, spend_tx(self.nodes[0], tx, self.nodeaddress)]
             for tx in all_rlt_txs(bip112txs_vary_OP_CSV_9_v2)
         ])
-
         # add BIP113 tx and -1 CSV tx
         # = MTP of prior block (not <) but < time put on current block
         bip113tx_v2.nLockTime = self.last_block_time - 600 * 5
         bip113signed2 = sign_transaction(self.nodes[0], bip113tx_v2)
+        self.send_failure_blocks([[bip113signed2]])
+
         success_txs = []
-        success_txs.append(bip113signed2)
         # add BIP 68 txs
         success_txs.extend(all_rlt_txs(bip68txs_v2[:8]))
         # Test #4


### PR DESCRIPTION
- Remove `LOCKTIME_MEDIAN_TIME_PAST` flag.
- Always use GetMedianTimePast() for CLTV calculations.
- Fix `test/functional/feature_csv_activation.py`, `bip113signed1` and `bip113signed2` are now invalid.