### PR TITLE
Remove block version restriction

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3721,19 +3721,6 @@ static bool ContextualCheckBlockHeader(const CChainParams &params,
                              "block timestamp too far in the future");
     }
 
-    // Reject outdated version blocks when 95% (75% on testnet) of the network
-    // has upgraded:
-    // check for version 2, 3 and 4 upgrades
-    const Consensus::Params &consensusParams = params.GetConsensus();
-    if ((block.nVersion < 2 && nHeight >= consensusParams.BIP34Height) ||
-        (block.nVersion < 3 && nHeight >= consensusParams.BIP66Height) ||
-        (block.nVersion < 4 && nHeight >= consensusParams.BIP65Height)) {
-        return state.Invalid(
-            BlockValidationResult::BLOCK_INVALID_HEADER,
-            strprintf("bad-version(0x%08x)", block.nVersion),
-            strprintf("rejected nVersion=0x%08x block", block.nVersion));
-    }
-
     return true;
 }
 

--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -129,20 +129,11 @@ class BIP65Test(BitcoinTestFramework):
         block.solve()
         self.nodes[0].p2p.send_and_ping(msg_block(block))
 
-        self.log.info("Test that blocks must now be at least version 4")
         tip = block.sha256
         block_time += 1
-        block = create_block(tip, create_coinbase(CLTV_HEIGHT), block_time)
-        block.nVersion = 3
-        block.solve()
-
-        with self.nodes[0].assert_debug_log(expected_msgs=['{}, bad-version(0x00000003)'.format(block.hash)]):
-            self.nodes[0].p2p.send_and_ping(msg_block(block))
-            assert_equal(int(self.nodes[0].getbestblockhash(), 16), tip)
-            self.nodes[0].p2p.sync_with_ping()
-
         self.log.info(
             "Test that invalid-according-to-cltv transactions cannot appear in a block")
+        block = create_block(tip, create_coinbase(CLTV_HEIGHT), block_time)
         block.nVersion = 4
 
         fundtx = create_transaction(self.nodes[0], self.coinbase_txids[1],

--- a/test/functional/feature_dersig.py
+++ b/test/functional/feature_dersig.py
@@ -53,24 +53,13 @@ class BIP66Test(BitcoinTestFramework):
             b)['tx'][0] for b in self.nodes[0].generate(DERSIG_HEIGHT - 1)]
         self.nodeaddress = self.nodes[0].getnewaddress()
 
-        self.log.info("Test that blocks must now be at least version 3")
+        self.log.info(
+            "Test that transactions with non-DER signatures cannot appear in a block")
         tip = self.nodes[0].getbestblockhash()
         block_time = self.nodes[0].getblockheader(tip)['mediantime'] + 1
         block = create_block(
             int(tip, 16), create_coinbase(DERSIG_HEIGHT), block_time)
-        block.nVersion = 2
-        block.rehash()
-        block.solve()
-
-        with self.nodes[0].assert_debug_log(expected_msgs=['{}, bad-version(0x00000002)'.format(block.hash)]):
-            self.nodes[0].p2p.send_and_ping(msg_block(block))
-            assert_equal(self.nodes[0].getbestblockhash(), tip)
-            self.nodes[0].p2p.sync_with_ping()
-
-        self.log.info(
-            "Test that transactions with non-DER signatures cannot appear in a block")
         block.nVersion = 3
-
         spendtx = create_transaction(self.nodes[0], self.coinbase_txids[1],
                                      self.nodeaddress, amount=1.0)
         unDERify(spendtx)


### PR DESCRIPTION
- Removes restrictions on nVersion of blocks.
- Fixes tests that check if certain block versions are invalid.