### PR TITLE
Rename fRequireStandard to fRequireStandardPolicy (and associated met…

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -206,7 +206,7 @@ public:
             pnSeed6_main, pnSeed6_main + ARRAYLEN(pnSeed6_main));
 
         fDefaultConsistencyChecks = false;
-        fRequireStandard = true;
+        fRequireStandardPolicy = true;
         m_is_test_chain = false;
         m_is_mockable_chain = false;
 
@@ -349,7 +349,7 @@ public:
             pnSeed6_test, pnSeed6_test + ARRAYLEN(pnSeed6_test));
 
         fDefaultConsistencyChecks = false;
-        fRequireStandard = false;
+        fRequireStandardPolicy = false;
         m_is_test_chain = true;
         m_is_mockable_chain = false;
 
@@ -459,7 +459,7 @@ public:
         vSeeds.clear();
 
         fDefaultConsistencyChecks = true;
-        fRequireStandard = true;
+        fRequireStandardPolicy = true;
         m_is_test_chain = true;
         m_is_mockable_chain = true;
 

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -65,7 +65,7 @@ public:
     /** Default value for -checkmempool and -checkblockindex argument */
     bool DefaultConsistencyChecks() const { return fDefaultConsistencyChecks; }
     /** Policy: Filter transactions that do not match well-defined patterns */
-    bool RequireStandard() const { return fRequireStandard; }
+    bool RequireStandardPolicy() const { return fRequireStandardPolicy; }
     /** If this chain is exclusively used for testing */
     bool IsTestChain() const { return m_is_test_chain; }
     /** If this chain allows time to be mocked */
@@ -111,7 +111,7 @@ protected:
     CBlock genesis;
     std::vector<SeedSpec6> vFixedSeeds;
     bool fDefaultConsistencyChecks;
-    bool fRequireStandard;
+    bool fRequireStandardPolicy;
     bool m_is_test_chain;
     bool m_is_mockable_chain;
     CCheckpointData checkpointData;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1037,7 +1037,8 @@ void SetupServerArgs(NodeContext &node) {
         "-acceptnonstdtxn",
         strprintf(
             "Relay and mine \"non-standard\" transactions (%sdefault: %u)",
-            "testnet/regtest only; ", defaultChainParams->RequireStandard()),
+            "testnet/regtest only; ",
+            defaultChainParams->RequireStandardPolicy()),
         ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY,
         OptionsCategory::NODE_RELAY);
     argsman.AddArg("-excessiveblocksize=<n>",
@@ -2015,9 +2016,9 @@ bool AppInitParameterInteraction(Config &config, const ArgsManager &args) {
         dustRelayFee = CFeeRate(n);
     }
 
-    fRequireStandard =
-        !args.GetBoolArg("-acceptnonstdtxn", !chainparams.RequireStandard());
-    if (!chainparams.IsTestChain() && !fRequireStandard) {
+    fRequireStandardPolicy = !args.GetBoolArg("-acceptnonstdtxn",
+        !chainparams.RequireStandardPolicy());
+    if (!chainparams.IsTestChain() && !fRequireStandardPolicy) {
         return InitError(strprintf(
             Untranslated(
                 "acceptnonstdtxn is not currently supported for %s chain"),

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -102,7 +102,7 @@ std::atomic_bool fImporting(false);
 std::atomic_bool fReindex(false);
 bool fHavePruned = false;
 bool fPruneMode = false;
-bool fRequireStandard = true;
+bool fRequireStandardPolicy = true;
 bool fCheckBlockIndex = false;
 bool fCheckpointsEnabled = DEFAULT_CHECKPOINTS_ENABLED;
 size_t nCoinCacheUsage = 5000 * 300;
@@ -460,7 +460,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs &args, Workspace &ws) {
 
     // Rather not work on nonstandard transactions (unless -testnet)
     std::string reason;
-    if (fRequireStandard && !IsStandardTx(tx, reason)) {
+    if (fRequireStandardPolicy && !IsStandardTx(tx, reason)) {
         return state.Invalid(TxValidationResult::TX_NOT_STANDARD, reason);
     }
 
@@ -558,7 +558,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs &args, Workspace &ws) {
     }
 
     // Check for non-standard pay-to-script-hash in inputs
-    if (fRequireStandard &&
+    if (fRequireStandardPolicy &&
         !AreInputsStandard(tx, m_view, ws.m_next_block_script_verify_flags)) {
         return state.Invalid(TxValidationResult::TX_NOT_STANDARD,
                              "bad-txns-nonstandard-inputs");

--- a/src/validation.h
+++ b/src/validation.h
@@ -135,7 +135,7 @@ extern std::condition_variable g_best_block_cv;
 extern uint256 g_best_block;
 extern std::atomic_bool fImporting;
 extern std::atomic_bool fReindex;
-extern bool fRequireStandard;
+extern bool fRequireStandardPolicy;
 extern bool fCheckBlockIndex;
 extern bool fCheckpointsEnabled;
 extern size_t nCoinCacheUsage;


### PR DESCRIPTION
- Rename global `fRequireStandard` to `fRequireStandardPolicy`.
- Rename method `RequireStandard` to `RequireStandardPolicy`.