### PR TITLE
Enforce undersize rule from genesis

### DIFF
--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -49,12 +49,10 @@ bool ContextualCheckTransaction(const Consensus::Params &params,
                              "bad-txns-nonfinal", "non-final transaction");
     }
 
-    if (IsMagneticAnomalyEnabled(params, nHeight)) {
-        // Size limit
-        if (::GetSerializeSize(tx, PROTOCOL_VERSION) < MIN_TX_SIZE) {
-            return state.Invalid(TxValidationResult::TX_CONSENSUS,
-                                 "bad-txns-undersize");
-        }
+    // Size limit
+    if (::GetSerializeSize(tx, PROTOCOL_VERSION) < MIN_TX_SIZE) {
+        return state.Invalid(TxValidationResult::TX_CONSENSUS,
+                                "bad-txns-undersize");
     }
 
     return true;

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -60,34 +60,34 @@ constexpr static struct {
     uint8_t extranonce;
     uint32_t nonce;
 } blockinfo[] = {
-    {1,  0x628b1e49}, {2,  0xac068108}, {11, 0x719c2619}, {2, 0x91559120},
-    {5,  0xf5037f52}, {9,  0xa98a3c5a}, {4,  0x8816f72d}, {3, 0xe0e9b66e},
-    {2,  0x8611e5e9}, {5,  0x8a36a2ae}, {5,  0x7ea8d188}, {2, 0x6aa0e1c6},
-    {5,  0x0062430b}, {2,  0xf03f169f}, {2,  0x4eba97db}, {4, 0xc35b347f},
-    {2,  0x52c5b0f0}, {5,  0x4e3c227d}, {2,  0x36f34401}, {5, 0x0a52608c},
-    {6,  0x66967a24}, {2,  0xa5a0b36b}, {2,  0x9349f573}, {4, 0x5dddf692},
-    {8,  0x944547b4}, {8,  0x435da16c}, {2,  0x77f07522}, {3, 0xaf9c007a},
-    {2,  0xa434d282}, {2,  0x7d93d231}, {8,  0x9a7c414e}, {9, 0x6c69144d},
-    {13, 0x8eb7cb31}, {5,  0x7e224d22}, {3,  0x701fa359}, {2, 0xb7dbf21f},
-    {5,  0x2945ae64}, {10, 0xfb2dbf18}, {2,  0xe581e82a}, {2, 0xa6573b53},
-    {8,  0x03e5075f}, {2,  0x65c9a263}, {3,  0xccb0a913}, {3, 0x38f3b43a},
-    {7,  0x1b946e22}, {6,  0x68ef7276}, {5,  0x8606b322}, {3, 0x5e73626c},
-    {2,  0xd7d91958}, {4,  0x2339a18e}, {2,  0x361c1145}, {2, 0xbd968835},
-    {3,  0x79499e34}, {2,  0xf4ba55bb}, {2,  0xfe638677}, {2, 0x19840618},
-    {2,  0x1ae4974c}, {3,  0xe35a03c},  {3,  0xaa03f5d6}, {2, 0x7f6cd731},
-    {3,  0x6f7c1755}, {9,  0x6250786b}, {3,  0x93ddc561}, {8, 0xf4fff27c},
-    {7,  0xae1ee12a}, {6,  0xe94b411f}, {10, 0x5e5db777}, {2, 0xef97a20b},
-    {3,  0x52dda1ae}, {2,  0x6a51e635}, {4,  0xe601b236}, {2, 0x541cdcd0},
-    {2,  0x53e3a77b}, {2,  0xd6b3b644}, {2,  0x7636046d}, {4, 0xdf3fa0d0},
-    {2,  0x38c940e3}, {5,  0xdbfca258}, {3,  0xf613aaa5}, {8, 0xa98a7a13},
-    {5,  0x2bf7a509}, {2,  0x31b5c0b8}, {2,  0xd052cc03}, {2, 0x3b48dc21},
-    {4,  0x51c76898}, {2,  0x753def12}, {4,  0x17436513}, {2, 0xac80fb6d},
-    {2,  0xc102c921}, {3,  0x55ce221b}, {3,  0xea4d7949}, {2, 0xc5b5fdb3},
-    {2,  0xc9b382e4}, {2,  0x1dff5208}, {2,  0xae27e31f}, {5, 0x8ff6b4ca},
-    {6,  0xe488427f}, {4,  0xa54a73cf}, {2,  0xac55b7b9}, {3, 0x39eff568},
-    {3,  0x39cbf2b9}, {20, 0x9735c689}, {2,  0x638102bf}, {4, 0xe8acaf83},
-    {7,  0x658828b7}, {2,  0xc0017647}, {2,  0x617a518b}, {6, 0x3f87930e},
-    {3,  0x38bc5102}, {2,  0x31a480d5},
+    {1,  0x7458c333}, {2, 0x4f87692f}, {3,  0xe4448bee}, {3,  0xcd574612},
+    {3,  0x5bc18aa4}, {5, 0xdbaeec2c}, {3,  0x2667b5c0}, {7,  0x8601b02b},
+    {3,  0xfb9632cc}, {6, 0x3227743e}, {3,  0x5f8eb6ac}, {4,  0x995aade0},
+    {5,  0xf83707af}, {6, 0x5eaeacc8}, {5,  0x8904dd0f}, {5,  0x1777db09},
+    {5,  0x9983d245}, {6, 0xc63ea3e8}, {5,  0x138f4f9f}, {3,  0x050350d0},
+    {3,  0x5e92f880}, {3, 0x3e92c08c}, {3,  0x8b2df62c}, {3,  0xcda57eb0},
+    {5,  0xeb7bff82}, {8, 0xb9c3129a}, {4,  0x300bf551}, {2,  0x21296be2},
+    {3,  0x7de2e084}, {5, 0x9f632535}, {3,  0x2e287bc6}, {4,  0xb59237de},
+    {10, 0x24a3f15e}, {5, 0x61af79d1}, {6,  0xda8bb49a}, {4,  0x686a46b5},
+    {6,  0x4460fd0c}, {2, 0x4e6a1940}, {4,  0xcb117cc0}, {6,  0xb5b3ab58},
+    {2,  0xabd841a6}, {5, 0x6fe14606}, {5,  0xdb206677}, {8,  0xfea51682},
+    {4,  0x34e87922}, {4, 0xac6dde44}, {4,  0x7d87e69f}, {3,  0xea2ca574},
+    {5,  0x125d0397}, {6, 0x5c3c794a}, {3,  0x42377608}, {5,  0x5bf48b3b},
+    {3,  0x27dfebe8}, {3, 0x4f982736}, {3,  0xcc11930b}, {4,  0xaafbdfa3},
+    {5,  0xf131a20a}, {5, 0xabfbedf5}, {4,  0xf0003e5c}, {4,  0xfe31362b},
+    {3,  0xe9d08362}, {3, 0x1247bf50}, {6,  0xf9324b62}, {5,  0x03fd9685},
+    {5,  0x8bf90170}, {3, 0xc95d7d70}, {5,  0x47c15edb}, {3,  0x7bca2618},
+    {4,  0x16262264}, {6, 0x2a058a73}, {2,  0x316f4d36}, {5,  0x03d00388},
+    {10, 0x75fb1f7e}, {4, 0x7516b914}, {2,  0xcda26b5d}, {5,  0xfe0d87cd},
+    {2,  0xb12d039c}, {4, 0x3d920303}, {2,  0x65e42878}, {3,  0xb7ba5a78},
+    {9,  0x07d51bd8}, {8, 0x7d248874}, {5,  0x0eee1b25}, {5,  0x0600770e},
+    {3,  0xcf5dcd70}, {4, 0x4eee7d58}, {3,  0x0205ca6c}, {4,  0x7a25eb28},
+    {3,  0x418406e0}, {8, 0x76a0a254}, {4,  0x91f60022}, {5,  0x1cf95b21},
+    {4,  0x8b5f1a54}, {3, 0xd4e81503}, {4,  0x0dca1f0e}, {8,  0xd640b02a},
+    {6,  0x489d711a}, {3, 0xc6f16d46}, {14, 0x2db7b2a8}, {10, 0x6a12c33c},
+    {3,  0xb9dc3270}, {4, 0xcf2a0162}, {3,  0xeaf1387e}, {3,  0xa3d5e1f0},
+    {2,  0xd9b22c59}, {4, 0xda118c1c}, {3,  0x7e900a4e}, {3,  0x02569532},
+    {5,  0xfcaadcde}, {3, 0xec9d9944},
 };
 
 const Amount BLOCKSUBSIDY = 50 * COIN;
@@ -114,14 +114,19 @@ void MinerTestingSetup::TestPackageSelection(
     // Test the ancestor feerate transaction selection.
     TestMemPoolEntryHelper entry;
 
+    // Padding so txs are not undersize
+    std::vector<uint8_t> padData(100);
+
     // Test that a medium fee transaction will be selected after a higher fee
     // rate package with a low fee rate parent.
     CMutableTransaction tx;
     tx.vin.resize(1);
     tx.vin[0].scriptSig = CScript() << OP_1;
     tx.vin[0].prevout = COutPoint(txFirst[0]->GetId(), 0);
-    tx.vout.resize(1);
+    tx.vout.resize(2);
     tx.vout[0].nValue = int64_t(MINERREWARD_INT - 1000) * SATOSHI;
+    tx.vout[1].nValue = Amount::zero();
+    tx.vout[1].scriptPubKey = CScript() << OP_RETURN << padData;
     // This tx has a low fee: 1000 satoshis.
     // Save this txid for later use.
     TxId parentTxId = tx.GetId();
@@ -151,6 +156,7 @@ void MinerTestingSetup::TestPackageSelection(
 
     std::unique_ptr<CBlockTemplate> pblocktemplate =
         AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey);
+    BOOST_CHECK_EQUAL(pblocktemplate->block.vtx.size(), 4);
     BOOST_CHECK(pblocktemplate->block.vtx[1]->GetId() == parentTxId);
     BOOST_CHECK(pblocktemplate->block.vtx[2]->GetId() == mediumFeeTxId);
     BOOST_CHECK(pblocktemplate->block.vtx[3]->GetId() == highFeeTxId);
@@ -189,20 +195,22 @@ void MinerTestingSetup::TestPackageSelection(
     lowFeeTxId = tx.GetId();
     m_node.mempool->addUnchecked(entry.Fee(feeToUse + 2 * SATOSHI).FromTx(tx));
     pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey);
-    BOOST_CHECK(pblocktemplate->block.vtx[1]->GetId() == parentTxId);
-    BOOST_CHECK(pblocktemplate->block.vtx[2]->GetId() == lowFeeTxId);
-    BOOST_CHECK(pblocktemplate->block.vtx[3]->GetId() == mediumFeeTxId);
-    BOOST_CHECK(pblocktemplate->block.vtx[4]->GetId() == freeTxId);
-    BOOST_CHECK(pblocktemplate->block.vtx[5]->GetId() == highFeeTxId);
+    BOOST_CHECK_EQUAL(pblocktemplate->block.vtx.size(), 6);
+    BOOST_CHECK_EQUAL(pblocktemplate->block.vtx[1]->GetId(), lowFeeTxId);
+    BOOST_CHECK_EQUAL(pblocktemplate->block.vtx[2]->GetId(), parentTxId);
+    BOOST_CHECK_EQUAL(pblocktemplate->block.vtx[3]->GetId(), freeTxId);
+    BOOST_CHECK_EQUAL(pblocktemplate->block.vtx[4]->GetId(), mediumFeeTxId);
+    BOOST_CHECK_EQUAL(pblocktemplate->block.vtx[5]->GetId(), highFeeTxId);
 
     // Test that transaction selection properly updates ancestor fee
     // calculations as ancestor transactions get included in a block. Add a
     // 0-fee transaction that has 2 outputs.
     tx.vin[0].prevout = COutPoint(txFirst[2]->GetId(), 0);
-    tx.vout.resize(2);
     tx.vout[0].nValue = int64_t(MINERREWARD_INT - 100000000) * SATOSHI;
+    tx.vout[0].scriptPubKey = CScript() << padData << OP_DROP;
     // 1BCC output.
     tx.vout[1].nValue = 100000000 * SATOSHI;
+    tx.vout[1].scriptPubKey = CScript();
     TxId freeTxId2 = tx.GetId();
     m_node.mempool->addUnchecked(
         entry.Fee(Amount::zero()).SpendsCoinbase(true).FromTx(tx));
@@ -230,7 +238,7 @@ void MinerTestingSetup::TestPackageSelection(
     tx.vout[0].nValue = (100000000 - 10000) * SATOSHI;
     m_node.mempool->addUnchecked(entry.Fee(10000 * SATOSHI).FromTx(tx));
     pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey);
-    BOOST_CHECK(pblocktemplate->block.vtx[3]->GetId() == lowFeeTxId2);
+    BOOST_CHECK_EQUAL(pblocktemplate->block.vtx[4]->GetId(), lowFeeTxId2);
 }
 
 void TestCoinbaseMessageEB(uint64_t eb, std::string cbmsg,
@@ -310,6 +318,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity) {
             // Make sure coinbase is BIP34 compliant
             txCoinbase.vin[0].scriptSig = CScript() << nHeight << OP_0;
             txCoinbase.vin[0].scriptSig.push_back(blockinfo[i].extranonce);
+            txCoinbase.vin[0].scriptSig.resize(100);
             txCoinbase.vout[0].scriptPubKey = CScript();
             pblock->vtx[0] = MakeTransactionRef(std::move(txCoinbase));
             if (txFirst.size() == 0) {
@@ -337,6 +346,8 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity) {
     // Just to make sure we can still make simple blocks.
     BOOST_CHECK(pblocktemplate =
                     AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey));
+
+    std::vector<uint8_t> padData(100);
 
     // block size > limit
     tx.vin.resize(1);
@@ -413,8 +424,11 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity) {
     // Double spend txn pair in mempool, template creation fails.
     tx.vin[0].prevout = COutPoint(txFirst[0]->GetId(), 0);
     tx.vin[0].scriptSig = CScript() << OP_1;
+    tx.vout.resize(2);
     tx.vout[0].nValue = MINERREWARD - HIGHFEE;
     tx.vout[0].scriptPubKey = CScript() << OP_1;
+    tx.vout[1].nValue = Amount::zero();
+    tx.vout[1].scriptPubKey = CScript() << OP_RETURN << padData;
     txid = tx.GetId();
     m_node.mempool->addUnchecked(
         entry.Fee(HIGHFEE).Time(GetTime()).SpendsCoinbase(true).FromTx(tx));
@@ -510,7 +524,6 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity) {
     // and for adding txs to the mempool.
     tx.vin[0].nSequence = ::ChainActive().Tip()->nHeight - 1;
     prevheights[0] = baseheight + 1;
-    tx.vout.resize(1);
     tx.vout[0].nValue = MINERREWARD - HIGHFEE;
     tx.vout[0].scriptPubKey = CScript() << OP_1;
     tx.nLockTime = 0;

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -860,17 +860,13 @@ BOOST_AUTO_TEST_CASE(test_IsStandard) {
 BOOST_AUTO_TEST_CASE(txsize_activation_test) {
     const Config &config = GetConfig();
     const Consensus::Params &params = config.GetChainParams().GetConsensus();
-    const int32_t magneticAnomalyActivationHeight =
-        params.magneticAnomalyHeight;
 
     // A minimaly sized transction.
     CTransaction minTx;
     TxValidationState state;
 
-    BOOST_CHECK(ContextualCheckTransaction(
-        params, minTx, state, magneticAnomalyActivationHeight - 1, 5678, 1234));
     BOOST_CHECK(!ContextualCheckTransaction(
-        params, minTx, state, magneticAnomalyActivationHeight, 5678, 1234));
+        params, minTx, state, 0, 5678, 1234));
     BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-txns-undersize");
 }
 


### PR DESCRIPTION
- Enforce transaction size limit from genesis, not only after `IsMagneticAnomalyEnabled` is true.
- In `miner_tests.cpp`, make coinbase string 100 bytes (and redo the PoW).
- In `miner_tests.cpp`, make all transactions greater than 100 bytes by adding an OP_RETURN padding output.
- Fix `txsize_activation_test`, check from genesis now and only once.