### PR TITLE
Add spent outputs to PrecomputedTransactionData

### DIFF
--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -325,9 +325,11 @@ static inline CTransactionRef MakeTransactionRef(Tx &&txIn) {
     return std::make_shared<const CTransaction>(std::forward<Tx>(txIn));
 }
 
+class CCoinsView;
 /** Precompute sighash midstate to avoid quadratic hashing */
 struct PrecomputedTransactionData {
     uint256 hashPrevouts, hashSequence, hashOutputs;
+    std::vector<CTxOut> m_spent_outputs;
 
     PrecomputedTransactionData()
         : hashPrevouts(), hashSequence(), hashOutputs() {}
@@ -335,7 +337,13 @@ struct PrecomputedTransactionData {
     PrecomputedTransactionData(const PrecomputedTransactionData &txdata) =
         default;
 
-    template <class T> explicit PrecomputedTransactionData(const T &tx);
+    template <class T>
+    explicit PrecomputedTransactionData(const T &tx,
+                                        std::vector<CTxOut> &&spent_outputs);
+
+    template <class T>
+    static PrecomputedTransactionData
+    FromCoinsView(const T &tx, const CCoinsView &coins_view);
 };
 
 #endif // BITCOIN_PRIMITIVES_TRANSACTION_H

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -200,6 +200,7 @@ add_boost_unit_tests_to_suite(bitcoin test_bitcoin
 		settings_tests.cpp
 		sigcache_tests.cpp
 		sigencoding_tests.cpp
+		sighash_bip341_tests.cpp
 		sighash_tests.cpp
 		sighashtype_tests.cpp
 		sigcheckcount_tests.cpp

--- a/src/test/script_p2sh_tests.cpp
+++ b/src/test/script_p2sh_tests.cpp
@@ -110,7 +110,7 @@ BOOST_AUTO_TEST_CASE(sign) {
     // ScriptSig:
     for (int i = 0; i < 8; i++) {
         CTransaction tx(txTo[i]);
-        PrecomputedTransactionData txdata(tx);
+        PrecomputedTransactionData txdata(tx, {txFrom.vout[i]});
         for (int j = 0; j < 8; j++) {
             CScript sigSave = txTo[i].vin[0].scriptSig;
             txTo[i].vin[0].scriptSig = txTo[j].vin[0].scriptSig;

--- a/src/test/sigcache_tests.cpp
+++ b/src/test/sigcache_tests.cpp
@@ -61,7 +61,8 @@ BOOST_AUTO_TEST_CASE(sig_pubkey_hash_variations) {
             "dde3c38e000000000151ffffffff010000000000000000016a00000000"),
         SER_NETWORK, PROTOCOL_VERSION);
     CTransaction dummyTx(deserialize, stream);
-    PrecomputedTransactionData txdata(dummyTx);
+    // spent_outputs can be empty here
+    PrecomputedTransactionData txdata(dummyTx, {});
     CachingTransactionSignatureChecker checker(&dummyTx, 0, 0 * SATOSHI, true,
                                                txdata);
 

--- a/src/test/sighash_bip341_tests.cpp
+++ b/src/test/sighash_bip341_tests.cpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2012-2019 Logos Foundation
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <chain.h>
+#include <coins.h>
+#include <hash.h>
+#include <script/script.h>
+#include <script/standard.h>
+
+#include <test/util/setup_common.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(sighash_bip341_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(prepare_spent_outputs) {
+    LOCK(cs_main);
+    CCoinsView coinsDummy;
+    CCoinsViewCache coins(&coinsDummy);
+
+    CMutableTransaction txFrom;
+    txFrom.vout.resize(1);
+    txFrom.vout[0].scriptPubKey =
+        GetScriptForDestination(ScriptHash(CScript() << OP_1));
+    txFrom.vout[0].nValue = 1000 * SATOSHI;
+
+    AddCoins(coins, CTransaction(txFrom), 0);
+
+    CMutableTransaction txTo;
+    txTo.vin.resize(1);
+    txTo.vin[0].prevout = COutPoint(txFrom.GetId(), 0);
+    txTo.vout.resize(1);
+    txTo.vout[0].scriptPubKey =
+        GetScriptForDestination(ScriptHash(CScript() << OP_2));
+    txTo.vout[0].nValue = 3000 * SATOSHI;
+
+    PrecomputedTransactionData txdata =
+        PrecomputedTransactionData::FromCoinsView(txTo, coins);
+    BOOST_CHECK(txdata.m_spent_outputs == txFrom.vout);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -133,7 +133,9 @@ ValidateCheckInputsForAllFlags(const CTransaction &tx, uint32_t failing_flags,
                                uint32_t required_flags, bool add_to_cache,
                                int expected_sigchecks)
     EXCLUSIVE_LOCKS_REQUIRED(cs_main) {
-    PrecomputedTransactionData txdata(tx);
+    PrecomputedTransactionData txdata =
+        PrecomputedTransactionData::FromCoinsView(
+            tx, ::ChainstateActive().CoinsTip());
 
     MMIXLinearCongruentialGenerator lcg;
     for (int i = 0; i < 4096; i++) {
@@ -267,7 +269,9 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, TestChain100Setup) {
         LOCK(cs_main);
 
         TxValidationState state;
-        PrecomputedTransactionData ptd_spend_tx(tx);
+        PrecomputedTransactionData ptd_spend_tx =
+            PrecomputedTransactionData::FromCoinsView(
+                tx, ::ChainstateActive().CoinsTip());
         int nSigChecksDummy;
 
         BOOST_CHECK(!CheckInputScripts(tx, state,
@@ -358,7 +362,9 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, TestChain100Setup) {
         TxValidationState state;
 
         CTransaction transaction(invalid_with_cltv_tx);
-        PrecomputedTransactionData txdata(transaction);
+        PrecomputedTransactionData txdata =
+            PrecomputedTransactionData::FromCoinsView(
+                transaction, ::ChainstateActive().CoinsTip());
 
         int nSigChecksRet;
         BOOST_CHECK(CheckInputScripts(transaction, state,
@@ -399,7 +405,9 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, TestChain100Setup) {
         TxValidationState state;
 
         CTransaction transaction(invalid_with_csv_tx);
-        PrecomputedTransactionData txdata(transaction);
+        PrecomputedTransactionData txdata =
+            PrecomputedTransactionData::FromCoinsView(
+                transaction, ::ChainstateActive().CoinsTip());
 
         int nSigChecksRet;
         BOOST_CHECK(CheckInputScripts(transaction, state,
@@ -455,7 +463,9 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, TestChain100Setup) {
 
             TxValidationState state;
             CTransaction transaction(tx);
-            PrecomputedTransactionData txdata(transaction);
+            PrecomputedTransactionData txdata =
+                PrecomputedTransactionData::FromCoinsView(
+                    transaction, ::ChainstateActive().CoinsTip());
             const uint32_t flags = STANDARD_SCRIPT_VERIFY_FLAGS;
             int nSigChecksDummy;
 
@@ -557,7 +567,9 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, TestChain100Setup) {
 
         TxValidationState state;
         CTransaction transaction(tx);
-        PrecomputedTransactionData txdata(transaction);
+        PrecomputedTransactionData txdata =
+            PrecomputedTransactionData::FromCoinsView(
+                transaction, ::ChainstateActive().CoinsTip());
 
         // This transaction is now invalid because the second signature is
         // missing.


### PR DESCRIPTION
This is required for the BIP341 sighash.