### PR TITLE
[backport#19953] Add TaggedHash function (BIP 340)

### DIFF
--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -5,6 +5,7 @@
 #include <hash.h>
 
 #include <crypto/hmac_sha512.h>
+#include <string>
 
 inline uint32_t ROTL32(uint32_t x, int8_t r) {
     return (x << r) | (x >> (32 - r));
@@ -86,4 +87,14 @@ uint256 SHA256Uint256(const uint256 &input) {
     uint256 result;
     CSHA256().Write(input.begin(), 32).Finalize(result.begin());
     return result;
+}
+
+CHashWriter TaggedHash(const std::string &tag) {
+    CHashWriter writer(SER_GETHASH, 0);
+    uint256 taghash;
+    CSHA256()
+        .Write((const uint8_t *)tag.data(), tag.size())
+        .Finalize(taghash.begin());
+    writer << taghash << taghash;
+    return writer;
 }

--- a/src/hash.h
+++ b/src/hash.h
@@ -15,6 +15,7 @@
 #include <uint256.h>
 #include <version.h>
 
+#include <string>
 #include <vector>
 
 typedef uint256 ChainCode;
@@ -202,5 +203,13 @@ uint32_t MurmurHash3(uint32_t nHashSeed, Span<const uint8_t> vDataToHash);
 
 void BIP32Hash(const ChainCode &chainCode, uint32_t nChild, uint8_t header,
                const uint8_t data[32], uint8_t output[64]);
+
+/** Return a CHashWriter primed for tagged hashes (as specified in BIP 340).
+ *
+ * The returned object will have SHA256(tag) written to it twice (= 64 bytes).
+ * A tagged hash can be computed by feeding the message into this object, and
+ * then calling CHashWriter::GetSHA256().
+ */
+CHashWriter TaggedHash(const std::string &tag);
 
 #endif // BITCOIN_HASH_H

--- a/src/test/hash_tests.cpp
+++ b/src/test/hash_tests.cpp
@@ -244,4 +244,24 @@ BOOST_AUTO_TEST_CASE(hashwriter_single_sha256_tests) {
                                "172b3f1b60a8ce26f"));
 }
 
+BOOST_AUTO_TEST_CASE(tagged_hash) {
+    CHashWriter h0 = TaggedHash("Tag");
+
+    BOOST_CHECK_EQUAL(h0.GetSHA256(),
+                      uint256S("566f4fc53cd1851d741b6c466fbb120ec14ae33cd4a3a37"
+                               "961df6fd0eff39a25"));
+
+    CHashWriter h1 = TaggedHash("Tag");
+    h1 << "The quick brown fox jumps over the lazy dog";
+    BOOST_CHECK_EQUAL(h1.GetSHA256(),
+                      uint256S("3f77201593bdfe9f54cabdd32080314a052a84ea23fc145"
+                               "bec9ff382829c1e64"));
+
+    CHashWriter h2 = TaggedHash("Tag2");
+    h2 << "The quick brown fox jumps over the lazy dog";
+    BOOST_CHECK_EQUAL(h1.GetSHA256(),
+                      uint256S("3749acbe03c67471510ccd50f3a1d920ca300f6057bb97d"
+                               "4565847857fca06ea"));
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This adds the TaggedHash function as defined by BIP340 to the hash module, which
is used in BIP340 and BIP341 to produce domain-separated hashes.

Part .

Required for #88.