### PR TITLE
Add ScriptExecutionData and thread it through EvalScript.

### DIFF
--- a/src/bench/verify_script.cpp
+++ b/src/bench/verify_script.cpp
@@ -31,9 +31,10 @@ static void VerifyNestedIfScript(benchmark::Bench &bench) {
     bench.run([&] {
         auto stack_copy = stack;
         ScriptExecutionMetrics metrics = {};
+        ScriptExecutionData execdata = {};
         ScriptError error;
         bool ret = EvalScript(stack_copy, script, 0, BaseSignatureChecker(),
-                              metrics, &error);
+                              metrics, execdata, &error);
         assert(ret);
     });
 }

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -9,6 +9,7 @@
 
 #include <primitives/transaction.h>
 #include <script/script_error.h>
+#include <script/script_exec_data.h>
 #include <script/script_flags.h>
 #include <script/script_metrics.h>
 #include <script/sighashtype.h>
@@ -84,13 +85,16 @@ using MutableTransactionSignatureChecker =
 
 bool EvalScript(std::vector<std::vector<uint8_t>> &stack, const CScript &script,
                 uint32_t flags, const BaseSignatureChecker &checker,
-                ScriptExecutionMetrics &metrics, ScriptError *error = nullptr);
+                ScriptExecutionMetrics &metrics, ScriptExecutionData &execdata,
+                ScriptError *error = nullptr);
 static inline bool EvalScript(std::vector<std::vector<uint8_t>> &stack,
                               const CScript &script, uint32_t flags,
                               const BaseSignatureChecker &checker,
                               ScriptError *error = nullptr) {
     ScriptExecutionMetrics dummymetrics;
-    return EvalScript(stack, script, flags, checker, dummymetrics, error);
+    ScriptExecutionData dummyexecdata;
+    return EvalScript(stack, script, flags, checker, dummymetrics,
+                      dummyexecdata, error);
 }
 
 /**

--- a/src/script/script_exec_data.h
+++ b/src/script/script_exec_data.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2021 The Logos Foundation
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_SCRIPT_SCRIPT_EXEC_DATA_H
+#define BITCOIN_SCRIPT_SCRIPT_EXEC_DATA_H
+
+#include <uint256.h>
+
+/**
+ * Struct for holding data generated during script execution which is used
+ * during script execution, e.g. for computing sig hashes.
+ */
+struct ScriptExecutionData {
+    /**
+     * Opcode position of the last executed OP_CODESEPARATOR.
+     * 
+     * This allows signatures to commit to certain code paths.
+     */
+    uint32_t m_codeseparator_pos;
+};
+
+#endif // BITCOIN_SCRIPT_SCRIPT_EXEC_DATA_H

--- a/src/test/sigcheckcount_tests.cpp
+++ b/src/test/sigcheckcount_tests.cpp
@@ -114,9 +114,10 @@ static void CheckEvalScript(const stacktype &original_stack,
         ScriptError err = ScriptError::UNKNOWN;
         stacktype stack{original_stack};
         ScriptExecutionMetrics metrics;
+        ScriptExecutionData execdata;
 
-        bool r =
-            EvalScript(stack, script, flags, dummysigchecker, metrics, &err);
+        bool r = EvalScript(stack, script, flags, dummysigchecker, metrics,
+                            execdata, &err);
         BOOST_CHECK(r);
         BOOST_CHECK_EQUAL(err, ScriptError::OK);
         BOOST_CHECK(stack == expected_stack);
@@ -211,9 +212,11 @@ BOOST_AUTO_TEST_CASE(test_evalscript) {
     {
         stacktype stack{txsigschnorr};
         ScriptExecutionMetrics metrics;
+        ScriptExecutionData execdata;
         metrics.nSigChecks = 12345;
         bool r = EvalScript(stack, CScript() << pub << OP_CHECKSIG,
-                            SCRIPT_ENABLE_SIGHASH_FORKID, dummysigchecker, metrics);
+                            SCRIPT_ENABLE_SIGHASH_FORKID, dummysigchecker,
+                            metrics, execdata);
         BOOST_CHECK(r);
         BOOST_CHECK_EQUAL(metrics.nSigChecks, 12346);
     }


### PR DESCRIPTION
This is required to collect the data for the BIP341 sighash, which, among other things, contains the last executed codeseparator position.

Required for #88.