### PR TITLE
Fix bench-bitcoin bug in BlockToJsonVerbose benchmark.

### DIFF
--- a/src/bench/rpc_blockchain.cpp
+++ b/src/bench/rpc_blockchain.cpp
@@ -5,6 +5,7 @@
 #include <bench/bench.h>
 #include <bench/data.h>
 
+#include <pubkey.h>
 #include <rpc/blockchain.h>
 #include <streams.h>
 #include <validation.h>
@@ -12,6 +13,7 @@
 #include <univalue.h>
 
 static void BlockToJsonVerbose(benchmark::Bench &bench) {
+    const ECCVerifyHandle verify_handle;
     CDataStream stream(benchmark::data::block413567, SER_NETWORK,
                        PROTOCOL_VERSION);
     char a = '\0';


### PR DESCRIPTION
62c2bc5 added the requirement to check LowS for verbose serialization of sigs, but we didn't fix the benchmarks.