### PR TITLE
Fix broken tests: SignSignature is called for tx with invalid inputs

### DIFF
--- a/src/test/script_p2sh_tests.cpp
+++ b/src/test/script_p2sh_tests.cpp
@@ -332,8 +332,8 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard) {
     txTo.vout[0].scriptPubKey =
         GetScriptForDestination(PKHash(key[1].GetPubKey()));
 
-    txTo.vin.resize(5);
-    for (int i = 0; i < 5; i++) {
+    txTo.vin.resize(4);
+    for (int i = 0; i < 4; i++) {
         txTo.vin[i].prevout = COutPoint(txFrom.GetId(), i);
     }
 

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -2408,6 +2408,7 @@ BOOST_AUTO_TEST_CASE(script_combineSigs) {
     pkSingle << ToByteVector(keys[0].GetPubKey()) << OP_CHECKSIG;
     BOOST_CHECK(keystore.AddCScript(pkSingle));
     scriptPubKey = GetScriptForDestination(ScriptHash(pkSingle));
+    txTo.vin[0].prevout = COutPoint(txFrom.GetId(), 0);
     BOOST_CHECK(SignSignature(keystore, CTransaction(txFrom), txTo, 0,
                               SigHashType().withForkId()));
     scriptSig = DataFromTransaction(txTo, 0, txFrom.vout[0]);
@@ -2426,6 +2427,7 @@ BOOST_AUTO_TEST_CASE(script_combineSigs) {
 
     // Hardest case:  Multisig 2-of-3
     scriptPubKey = GetScriptForMultisig(2, pubkeys);
+    txTo.vin[0].prevout = COutPoint(txFrom.GetId(), 0);
     BOOST_CHECK(keystore.AddCScript(scriptPubKey));
     BOOST_CHECK(SignSignature(keystore, CTransaction(txFrom), txTo, 0,
                               SigHashType().withForkId()));


### PR DESCRIPTION
In a few places, SignSignature is called with transactions that have inputs that don't have a corresponding output.

- In DoS_mapOrphans, adds 2777 inputs to `tx`, but doesn't add the corresponding outputs to `txPrev`.
- In AreInputsStandard, someone typed 5 instead of 4.
- In script_combineSigs, `txFrom` is updated, but `txTo` doesn't have its corresponding prevout updated.