### PR TITLE
Require PrecomputedTransactionData in MutableTransactionSignatureCreator

### DIFF
--- a/src/psbt.cpp
+++ b/src/psbt.cpp
@@ -169,13 +169,21 @@ void UpdatePSBTOutput(const SigningProvider &provider,
     SignatureData sigdata;
     psbt_out.FillSignatureData(sigdata);
 
+    // Collect spent outputs for BIP341 sighash
+    std::vector<CTxOut> spent_outputs;
+    spent_outputs.reserve(psbt.inputs.size());
+    for (const PSBTInput &input : psbt.inputs) {
+        spent_outputs.push_back(input.utxo);
+    }
+    const PrecomputedTransactionData txdata(*psbt.tx, std::move(spent_outputs));
+
     // Construct a would-be spend of this output, to update sigdata with.
     // Note that ProduceSignature is used to fill in metadata (not actual
     // signatures), so provider does not need to provide any private keys (it
     // can be a HidingSigningProvider).
     MutableTransactionSignatureCreator creator(
         psbt.tx ? &psbt.tx.value() : nullptr, /* index */ 0, out.nValue,
-        SigHashType().withForkId());
+        SigHashType().withForkId(), txdata);
     ProduceSignature(provider, creator, out.scriptPubKey, sigdata);
 
     // Put redeem_script and key paths, into PSBTOutput.
@@ -211,8 +219,15 @@ bool SignPSBTInput(const SigningProvider &provider,
         sig_complete = ProduceSignature(provider, DUMMY_SIGNATURE_CREATOR,
                                         utxo.scriptPubKey, sigdata);
     } else {
+        // Collect spent outputs for BIP341 sighash
+        std::vector<CTxOut> spent_outputs;
+        spent_outputs.reserve(psbt.inputs.size());
+        for (const PSBTInput &input : psbt.inputs) {
+            spent_outputs.push_back(input.utxo);
+        }
+        const PrecomputedTransactionData txdata(tx, std::move(spent_outputs));
         MutableTransactionSignatureCreator creator(&tx, index, utxo.nValue,
-                                                   sighash);
+                                                   sighash, txdata);
         sig_complete =
             ProduceSignature(provider, creator, utxo.scriptPubKey, sigdata);
     }

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -45,7 +45,8 @@ class MutableTransactionSignatureCreator : public BaseSignatureCreator {
 public:
     MutableTransactionSignatureCreator(
         const CMutableTransaction *txToIn, unsigned int nInIn,
-        const Amount &amountIn, SigHashType sigHashTypeIn = SigHashType());
+        const Amount &amountIn, SigHashType sigHashTypeIn,
+        const PrecomputedTransactionData &txdata);
     const BaseSignatureChecker &Checker() const override { return checker; }
     bool CreateSig(const SigningProvider &provider,
                    std::vector<uint8_t> &vchSig, const CKeyID &keyid,
@@ -173,9 +174,10 @@ bool ProduceSignature(const SigningProvider &provider,
                       const CScript &scriptPubKey, SignatureData &sigdata);
 
 /** Produce a script signature for a transaction. */
-bool SignSignature(const SigningProvider &provider, const CScript &fromPubKey,
+bool SignSignature(const SigningProvider &provider,
+                   const PrecomputedTransactionData &txdata,
                    CMutableTransaction &txTo, unsigned int nIn,
-                   const Amount amount, SigHashType sigHashType);
+                   SigHashType sigHashType);
 bool SignSignature(const SigningProvider &provider, const CTransaction &txFrom,
                    CMutableTransaction &txTo, unsigned int nIn,
                    SigHashType sigHashType);

--- a/src/test/fuzz/script_sign.cpp
+++ b/src/test/fuzz/script_sign.cpp
@@ -102,7 +102,7 @@ void test_one_input(const std::vector<uint8_t> &buffer) {
         if (mutable_transaction && tx_out &&
             mutable_transaction->vin.size() > n_in) {
             SignatureData signature_data_1 =
-                DataFromTransaction(*mutable_transaction, n_in, *tx_out);
+                DataFromTransaction(*mutable_transaction, n_in, {*tx_out});
             CTxIn input;
             UpdateInput(input, signature_data_1);
             const CScript script = ConsumeScript(fuzzed_data_provider);
@@ -136,7 +136,7 @@ void test_one_input(const std::vector<uint8_t> &buffer) {
                 MutableTransactionSignatureCreator signature_creator{
                     &tx_to, n_in, ConsumeMoney(fuzzed_data_provider),
                     SigHashType(
-                        fuzzed_data_provider.ConsumeIntegral<uint32_t>())};
+                        fuzzed_data_provider.ConsumeIntegral<uint32_t>()), {}};
                 std::vector<uint8_t> vch_sig;
                 CKeyID address;
                 if (fuzzed_data_provider.ConsumeBool()) {

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -2351,11 +2351,14 @@ SignatureData CombineSignatures(const CTxOut &txout,
                                 const CMutableTransaction &tx,
                                 const SignatureData &scriptSig1,
                                 const SignatureData &scriptSig2) {
+    assert(tx.vin.size() == 1);
     SignatureData data;
     data.MergeSignatureData(scriptSig1);
     data.MergeSignatureData(scriptSig2);
+    const PrecomputedTransactionData txdata(tx, {txout});
     ProduceSignature(DUMMY_SIGNING_PROVIDER,
-                     MutableTransactionSignatureCreator(&tx, 0, txout.nValue),
+                     MutableTransactionSignatureCreator(&tx, 0, txout.nValue,
+                                                        SigHashType(), txdata),
                      txout.scriptPubKey, data);
     return data;
 }

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -431,23 +431,25 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, TestChain100Setup) {
         tx.vout[0].nValue = 22 * CENT;
         tx.vout[0].scriptPubKey = p2pk_scriptPubKey;
 
+        const PrecomputedTransactionData precomputed_txdata(
+            tx, {spend_tx.vout[0], spend_tx.vout[3]});
         // Sign
         {
             SignatureData sigdata;
+            MutableTransactionSignatureCreator creator(
+                &tx, 0, 11 * CENT, SigHashType().withForkId(),
+                precomputed_txdata);
             BOOST_CHECK(ProduceSignature(
-                keystore,
-                MutableTransactionSignatureCreator(&tx, 0, 11 * CENT,
-                                                   SigHashType().withForkId()),
-                spend_tx.vout[0].scriptPubKey, sigdata));
+                keystore, creator, spend_tx.vout[0].scriptPubKey, sigdata));
             UpdateInput(tx.vin[0], sigdata);
         }
         {
             SignatureData sigdata;
+            MutableTransactionSignatureCreator creator(
+                &tx, 1, 11 * CENT, SigHashType().withForkId(),
+                precomputed_txdata);
             BOOST_CHECK(ProduceSignature(
-                keystore,
-                MutableTransactionSignatureCreator(&tx, 1, 11 * CENT,
-                                                   SigHashType().withForkId()),
-                spend_tx.vout[3].scriptPubKey, sigdata));
+                keystore, creator, spend_tx.vout[3].scriptPubKey, sigdata));
             UpdateInput(tx.vin[1], sigdata);
         }
 


### PR DESCRIPTION
This is so we can sign BIP341 signatures, which need the spent outputs, which is provided in PrecomputedTransactionData.