### PR TITLE
Always require PrecomputedTransactionData in GenericTransactionSignatureChecker

### DIFF
--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -703,7 +703,7 @@ static void MutateTxSign(CMutableTransaction &tx, const std::string &flagStr) {
         const Amount amount = coin.GetTxOut().nValue;
 
         SignatureData sigdata =
-            DataFromTransaction(mergedTx, i, coin.GetTxOut());
+            DataFromTransaction(mergedTx, i, txdata);
         // Only sign SIGHASH_SINGLE if there's a corresponding output:
         if ((sigHashType.getBaseType() != BaseSigHashType::SINGLE) ||
             (i < mergedTx.vout.size())) {

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -807,7 +807,8 @@ static UniValue combinerawtransaction(const Config &config,
         // ... and merge in other signatures:
         for (const CMutableTransaction &txv : txVariants) {
             if (txv.vin.size() > i) {
-                sigdata.MergeSignatureData(DataFromTransaction(txv, i, txout));
+                sigdata.MergeSignatureData(
+                    DataFromTransaction(txv, i, txdata));
             }
         }
         ProduceSignature(DUMMY_SIGNING_PROVIDER,

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -61,9 +61,6 @@ private:
     const PrecomputedTransactionData *txdata;
 
 public:
-    GenericTransactionSignatureChecker(const T *txToIn, unsigned int nInIn,
-                                       const Amount &amountIn)
-        : txTo(txToIn), nIn(nInIn), amount(amountIn), txdata(nullptr) {}
     GenericTransactionSignatureChecker(
         const T *txToIn, unsigned int nInIn, const Amount &amountIn,
         const PrecomputedTransactionData &txdataIn)

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -184,7 +184,8 @@ bool SignSignature(const SigningProvider &provider, const CTransaction &txFrom,
 
 /** Extract signature data from a transaction input, and insert it. */
 SignatureData DataFromTransaction(const CMutableTransaction &tx,
-                                  unsigned int nIn, const CTxOut &txout);
+                                  unsigned int nIn,
+                                  const PrecomputedTransactionData &txdata);
 void UpdateInput(CTxIn &input, const SignatureData &data);
 
 /**

--- a/src/test/script_p2sh_tests.cpp
+++ b/src/test/script_p2sh_tests.cpp
@@ -39,11 +39,11 @@ static bool Verify(const CScript &scriptSig, const CScript &scriptPubKey,
     txTo.vin[0].scriptSig = scriptSig;
     txTo.vout[0].nValue = SATOSHI;
 
-    return VerifyScript(
-        scriptSig, scriptPubKey,
-        SCRIPT_ENABLE_SIGHASH_FORKID,
-        MutableTransactionSignatureChecker(&txTo, 0, txFrom.vout[0].nValue),
-        &err);
+    PrecomputedTransactionData txdata(txTo, std::vector(txTo.vout));
+    return VerifyScript(scriptSig, scriptPubKey, SCRIPT_ENABLE_SIGHASH_FORKID,
+                        MutableTransactionSignatureChecker(
+                            &txTo, 0, txFrom.vout[0].nValue, txdata),
+                        &err);
 }
 
 BOOST_FIXTURE_TEST_SUITE(script_p2sh_tests, BasicTestingSetup)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2768,20 +2768,31 @@ bool CWallet::SignTransaction(CMutableTransaction &tx,
         }
     }
 
-    // At this point, one input was not fully signed otherwise we would have
-    // exited already Find that input and figure out what went wrong.
+    std::vector<CTxOut> spent_outputs(tx.vin.size());
+    std::vector<bool> has_coin(tx.vin.size());
     for (size_t i = 0; i < tx.vin.size(); i++) {
         // Get the prevout
         CTxIn &txin = tx.vin[i];
         auto coin = coins.find(txin.prevout);
         if (coin == coins.end() || coin->second.IsSpent()) {
             input_errors[i] = "Input not found or already spent";
+            // Just to be safe, sign unspendable if UTXO doesn't exist
+            spent_outputs[i].scriptPubKey = CScript() << OP_RETURN;
             continue;
         }
+        spent_outputs[i] = coin->second.GetTxOut();
+        has_coin[i] = true;
+    }
+    const PrecomputedTransactionData txdata(tx, std::move(spent_outputs));
 
+    // At this point, one input was not fully signed otherwise we would have
+    // exited already Find that input and figure out what went wrong.
+    for (size_t i = 0; i < tx.vin.size(); i++) {
+        if (!has_coin[i]) {
+            continue;
+        }
         // Check if this input is complete
-        SignatureData sigdata =
-            DataFromTransaction(tx, i, coin->second.GetTxOut());
+        SignatureData sigdata = DataFromTransaction(tx, i, txdata);
         if (!sigdata.complete) {
             input_errors[i] = "Unable to sign input, missing keys";
             continue;


### PR DESCRIPTION
Basically deletes the constructor which sets txdata to nullptr.

This change is required for BIP341 sighashes, as PrecomputedTransactionData contains m_spent_outputs, which is required for computing parts of the sighash.