### PR TITLE
Make SignatureHash fallible

### DIFF
--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -22,11 +22,11 @@ class CTransaction;
 class uint256;
 
 template <class T>
-uint256 SignatureHash(const CScript &scriptCode, const T &txTo,
-                      unsigned int nIn, SigHashType sigHashType,
-                      const Amount amount,
-                      const PrecomputedTransactionData *cache = nullptr,
-                      uint32_t flags = SCRIPT_ENABLE_SIGHASH_FORKID);
+bool SignatureHash(uint256 &sighashOut, const CScript &scriptCode,
+                   const T &txTo, unsigned int nIn, SigHashType sigHashType,
+                   const Amount amount,
+                   const PrecomputedTransactionData *cache = nullptr,
+                   uint32_t flags = SCRIPT_ENABLE_SIGHASH_FORKID);
 
 class BaseSignatureChecker {
 public:

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -27,8 +27,10 @@ bool MutableTransactionSignatureCreator::CreateSig(
     if (!provider.GetKey(address, key)) {
         return false;
     }
-
-    uint256 hash = SignatureHash(scriptCode, *txTo, nIn, sigHashType, amount);
+    uint256 hash;
+    if (!SignatureHash(hash, scriptCode, *txTo, nIn, sigHashType, amount)) {
+        return false;
+    }
     if (!key.SignECDSA(hash, vchSig)) {
         return false;
     }

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -22,8 +22,9 @@ BOOST_FIXTURE_TEST_SUITE(multisig_tests, BasicTestingSetup)
 static CScript sign_multisig(const CScript &scriptPubKey,
                              const std::vector<CKey> &keys,
                              const CMutableTransaction &tx, int whichIn) {
-    uint256 hash = SignatureHash(scriptPubKey, CTransaction(tx), whichIn,
-                                 SigHashType(), Amount::zero());
+    uint256 hash;
+    BOOST_CHECK(SignatureHash(hash, scriptPubKey, CTransaction(tx), whichIn,
+                              SigHashType(), Amount::zero()));
 
     CScript result;
     // CHECKMULTISIG bug workaround

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -338,8 +338,9 @@ public:
                  unsigned int lenR = 32, unsigned int lenS = 32,
                  Amount amount = Amount::zero(),
                  uint32_t sigFlags = SCRIPT_ENABLE_SIGHASH_FORKID) {
-        uint256 hash = SignatureHash(script, CTransaction(spendTx), 0,
-                                     sigHashType, amount, nullptr, sigFlags);
+        uint256 hash;
+        BOOST_CHECK(SignatureHash(hash, script, CTransaction(spendTx), 0,
+                                  sigHashType, amount, nullptr, sigFlags));
         std::vector<uint8_t> vchSig = DoSignECDSA(key, hash, lenR, lenS);
         vchSig.push_back(static_cast<uint8_t>(sigHashType.getRawSigHashType()));
         DoPush(vchSig);
@@ -350,8 +351,9 @@ public:
     PushSigSchnorr(const CKey &key, SigHashType sigHashType = SigHashType(),
                    Amount amount = Amount::zero(),
                    uint32_t sigFlags = SCRIPT_ENABLE_SIGHASH_FORKID) {
-        uint256 hash = SignatureHash(script, CTransaction(spendTx), 0,
-                                     sigHashType, amount, nullptr, sigFlags);
+        uint256 hash;
+        BOOST_CHECK(SignatureHash(hash, script, CTransaction(spendTx), 0,
+                                  sigHashType, amount, nullptr, sigFlags));
         std::vector<uint8_t> vchSig = DoSignSchnorr(key, hash);
         vchSig.push_back(static_cast<uint8_t>(sigHashType.getRawSigHashType()));
         DoPush(vchSig);
@@ -384,8 +386,9 @@ public:
         uint32_t sigFlags = SCRIPT_ENABLE_SIGHASH_FORKID) {
         // This calculates a pubkey to verify with a given ECDSA transaction
         // signature.
-        uint256 hash = SignatureHash(script, CTransaction(spendTx), 0,
-                                     sigHashType, amount, nullptr, sigFlags);
+        uint256 hash;
+        BOOST_CHECK(SignatureHash(hash, script, CTransaction(spendTx), 0,
+                                  sigHashType, amount, nullptr, sigFlags));
 
         assert(rdata.size() <= 32);
         assert(sdata.size() <= 32);
@@ -2151,8 +2154,9 @@ BOOST_AUTO_TEST_CASE(script_cltv_truncated) {
 static CScript sign_multisig(const CScript &scriptPubKey,
                              const std::vector<CKey> &keys,
                              const CTransaction &transaction) {
-    uint256 hash = SignatureHash(scriptPubKey, transaction, 0, SigHashType(),
-                                 Amount::zero());
+    uint256 hash;
+    BOOST_CHECK(SignatureHash(hash, scriptPubKey, transaction, 0, SigHashType(),
+                              Amount::zero()));
 
     CScript result;
     //
@@ -2439,22 +2443,25 @@ BOOST_AUTO_TEST_CASE(script_combineSigs) {
 
     // A couple of partially-signed versions:
     std::vector<uint8_t> sig1;
-    uint256 hash1 = SignatureHash(scriptPubKey, CTransaction(txTo), 0,
-                                  SigHashType().withForkId(), Amount::zero());
+    uint256 hash1;
+    BOOST_CHECK(SignatureHash(hash1, scriptPubKey, CTransaction(txTo), 0,
+                              SigHashType().withForkId(), Amount::zero()));
     BOOST_CHECK(keys[0].SignECDSA(hash1, sig1));
     sig1.push_back(SIGHASH_ALL | SIGHASH_FORKID);
     std::vector<uint8_t> sig2;
-    uint256 hash2 = SignatureHash(
-        scriptPubKey, CTransaction(txTo), 0,
+    uint256 hash2;
+    BOOST_CHECK(SignatureHash(
+        hash2, scriptPubKey, CTransaction(txTo), 0,
         SigHashType().withBaseType(BaseSigHashType::NONE).withForkId(),
-        Amount::zero());
+        Amount::zero()));
     BOOST_CHECK(keys[1].SignECDSA(hash2, sig2));
     sig2.push_back(SIGHASH_NONE | SIGHASH_FORKID);
     std::vector<uint8_t> sig3;
-    uint256 hash3 = SignatureHash(
-        scriptPubKey, CTransaction(txTo), 0,
+    uint256 hash3;
+    BOOST_CHECK(SignatureHash(
+        hash3, scriptPubKey, CTransaction(txTo), 0,
         SigHashType().withBaseType(BaseSigHashType::SINGLE).withForkId(),
-        Amount::zero());
+        Amount::zero()));
     BOOST_CHECK(keys[2].SignECDSA(hash3, sig3));
     sig3.push_back(SIGHASH_SINGLE | SIGHASH_FORKID);
 

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -142,13 +142,15 @@ BOOST_AUTO_TEST_CASE(sighash_test) {
 
         uint256 shref =
             SignatureHashOld(scriptCode, CTransaction(txTo), nIn, nHashType);
-        uint256 shold = SignatureHash(scriptCode, CTransaction(txTo), nIn,
-                                      sigHashType, Amount::zero(), nullptr, 0);
+        uint256 shold;
+        BOOST_CHECK(SignatureHash(shold, scriptCode, CTransaction(txTo), nIn,
+                                  sigHashType, Amount::zero(), nullptr, 0));
         BOOST_CHECK(shold == shref);
 
         // Check the impact of the forkid flag.
-        uint256 shreg = SignatureHash(scriptCode, CTransaction(txTo), nIn,
-                                      sigHashType, Amount::zero());
+        uint256 shreg;
+        BOOST_CHECK(SignatureHash(shreg, scriptCode, CTransaction(txTo), nIn,
+                                  sigHashType, Amount::zero()));
         if (sigHashType.hasForkId()) {
             BOOST_CHECK(nHashType & SIGHASH_FORKID);
             BOOST_CHECK(shreg != shref);
@@ -158,33 +160,39 @@ BOOST_AUTO_TEST_CASE(sighash_test) {
         }
 
         // Make sure replay protection works as expected.
-        uint256 shrep = SignatureHash(scriptCode, CTransaction(txTo), nIn,
-                                      sigHashType, Amount::zero(), nullptr,
-                                      SCRIPT_ENABLE_SIGHASH_FORKID |
-                                          SCRIPT_ENABLE_REPLAY_PROTECTION);
+        uint256 shrep;
+        BOOST_CHECK(SignatureHash(shrep, scriptCode, CTransaction(txTo), nIn,
+                                  sigHashType, Amount::zero(), nullptr,
+                                  SCRIPT_ENABLE_SIGHASH_FORKID |
+                                      SCRIPT_ENABLE_REPLAY_PROTECTION));
         uint32_t newForkValue = 0xff0000 | ((nHashType >> 8) ^ 0xdead);
-        uint256 manualshrep = SignatureHash(
-            scriptCode, CTransaction(txTo), nIn,
-            sigHashType.withForkValue(newForkValue), Amount::zero());
+        uint256 manualshrep;
+        BOOST_CHECK(SignatureHash(manualshrep, scriptCode, CTransaction(txTo),
+                                  nIn, sigHashType.withForkValue(newForkValue),
+                                  Amount::zero()));
         BOOST_CHECK(shrep == manualshrep);
 
         // Replay protection works even if the hash is of the form 0xffxxxx
-        uint256 shrepff = SignatureHash(
-            scriptCode, CTransaction(txTo), nIn,
+        uint256 shrepff;
+        BOOST_CHECK(SignatureHash(
+            shrepff, scriptCode, CTransaction(txTo), nIn,
             sigHashType.withForkValue(newForkValue), Amount::zero(), nullptr,
-            SCRIPT_ENABLE_SIGHASH_FORKID | SCRIPT_ENABLE_REPLAY_PROTECTION);
-        uint256 manualshrepff = SignatureHash(
-            scriptCode, CTransaction(txTo), nIn,
-            sigHashType.withForkValue(newForkValue ^ 0xdead), Amount::zero());
+            SCRIPT_ENABLE_SIGHASH_FORKID | SCRIPT_ENABLE_REPLAY_PROTECTION));
+        uint256 manualshrepff;
+        BOOST_CHECK(SignatureHash(
+            manualshrepff, scriptCode, CTransaction(txTo), nIn,
+            sigHashType.withForkValue(newForkValue ^ 0xdead), Amount::zero()));
         BOOST_CHECK(shrepff == manualshrepff);
 
-        uint256 shrepabcdef = SignatureHash(
-            scriptCode, CTransaction(txTo), nIn,
+        uint256 shrepabcdef;
+        BOOST_CHECK(SignatureHash(
+            shrepabcdef, scriptCode, CTransaction(txTo), nIn,
             sigHashType.withForkValue(0xabcdef), Amount::zero(), nullptr,
-            SCRIPT_ENABLE_SIGHASH_FORKID | SCRIPT_ENABLE_REPLAY_PROTECTION);
-        uint256 manualshrepabcdef =
-            SignatureHash(scriptCode, CTransaction(txTo), nIn,
-                          sigHashType.withForkValue(0xff1342), Amount::zero());
+            SCRIPT_ENABLE_SIGHASH_FORKID | SCRIPT_ENABLE_REPLAY_PROTECTION));
+        uint256 manualshrepabcdef;
+        BOOST_CHECK(
+            SignatureHash(manualshrepabcdef, scriptCode, CTransaction(txTo), nIn,
+                          sigHashType.withForkValue(0xff1342), Amount::zero()));
         BOOST_CHECK(shrepabcdef == manualshrepabcdef);
 
 #if defined(PRINT_SIGHASH_JSON)
@@ -259,17 +267,20 @@ BOOST_AUTO_TEST_CASE(sighash_from_data) {
             continue;
         }
 
-        uint256 shreg =
-            SignatureHash(scriptCode, *tx, nIn, sigHashType, Amount::zero());
+        uint256 shreg;
+        BOOST_CHECK(SignatureHash(shreg, scriptCode, *tx, nIn, sigHashType,
+                                  Amount::zero()));
         BOOST_CHECK_MESSAGE(shreg.GetHex() == sigHashRegHex, strTest);
 
-        uint256 shold = SignatureHash(scriptCode, *tx, nIn, sigHashType,
-                                      Amount::zero(), nullptr, 0);
+        uint256 shold;
+        BOOST_CHECK(SignatureHash(shold, scriptCode, *tx, nIn, sigHashType,
+                                  Amount::zero(), nullptr, 0));
         BOOST_CHECK_MESSAGE(shold.GetHex() == sigHashOldHex, strTest);
 
-        uint256 shrep = SignatureHash(
-            scriptCode, *tx, nIn, sigHashType, Amount::zero(), nullptr,
-            SCRIPT_ENABLE_SIGHASH_FORKID | SCRIPT_ENABLE_REPLAY_PROTECTION);
+        uint256 shrep;
+        BOOST_CHECK(SignatureHash(
+            shrep, scriptCode, *tx, nIn, sigHashType, Amount::zero(), nullptr,
+            SCRIPT_ENABLE_SIGHASH_FORKID | SCRIPT_ENABLE_REPLAY_PROTECTION));
         BOOST_CHECK_MESSAGE(shrep.GetHex() == sigHashRepHex, strTest);
     }
 }

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -51,9 +51,10 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, TestChain100Setup) {
 
         // Sign:
         std::vector<uint8_t> vchSig;
-        uint256 hash = SignatureHash(scriptPubKey, CTransaction(spends[i]), 0,
-                                     SigHashType().withForkId(),
-                                     m_coinbase_txns[0]->vout[0].nValue);
+        uint256 hash;
+        BOOST_CHECK(SignatureHash(hash, scriptPubKey, CTransaction(spends[i]),
+                                  0, SigHashType().withForkId(),
+                                  m_coinbase_txns[0]->vout[0].nValue));
         BOOST_CHECK(coinbaseKey.SignECDSA(hash, vchSig));
         vchSig.push_back(uint8_t(SIGHASH_ALL | SIGHASH_FORKID));
         spends[i].vin[0].scriptSig << vchSig;
@@ -215,9 +216,10 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, TestChain100Setup) {
         noppyScriptPubKey << OP_IF << OP_NOP10 << OP_ENDIF << OP_1;
         funding_tx.vout[0].scriptPubKey = noppyScriptPubKey;
         std::vector<uint8_t> fundingVchSig;
-        uint256 fundingSigHash = SignatureHash(
-            p2pk_scriptPubKey, CTransaction(funding_tx), 0,
-            SigHashType().withForkId(), m_coinbase_txns[0]->vout[0].nValue);
+        uint256 fundingSigHash;
+        BOOST_CHECK(SignatureHash(
+            fundingSigHash, p2pk_scriptPubKey, CTransaction(funding_tx), 0,
+            SigHashType().withForkId(), m_coinbase_txns[0]->vout[0].nValue));
         BOOST_CHECK(coinbaseKey.SignECDSA(fundingSigHash, fundingVchSig));
         fundingVchSig.push_back(uint8_t(SIGHASH_ALL | SIGHASH_FORKID));
         funding_tx.vin[0].scriptSig << fundingVchSig;
@@ -343,9 +345,11 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, TestChain100Setup) {
 
         // Sign
         std::vector<uint8_t> vchSig;
-        uint256 hash = SignatureHash(
-            spend_tx.vout[1].scriptPubKey, CTransaction(invalid_with_cltv_tx),
-            0, SigHashType().withForkId(), spend_tx.vout[1].nValue);
+        uint256 hash;
+        BOOST_CHECK(SignatureHash(hash, spend_tx.vout[1].scriptPubKey,
+                                  CTransaction(invalid_with_cltv_tx), 0,
+                                  SigHashType().withForkId(),
+                                  spend_tx.vout[1].nValue));
         BOOST_CHECK(coinbaseKey.SignECDSA(hash, vchSig));
         vchSig.push_back(uint8_t(SIGHASH_ALL | SIGHASH_FORKID));
         invalid_with_cltv_tx.vin[0].scriptSig = CScript() << vchSig << 101;
@@ -387,9 +391,11 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, TestChain100Setup) {
 
         // Sign
         std::vector<uint8_t> vchSig;
-        uint256 hash = SignatureHash(
-            spend_tx.vout[2].scriptPubKey, CTransaction(invalid_with_csv_tx), 0,
-            SigHashType().withForkId(), spend_tx.vout[2].nValue);
+        uint256 hash;
+        BOOST_CHECK(SignatureHash(hash, spend_tx.vout[2].scriptPubKey,
+                                  CTransaction(invalid_with_csv_tx), 0,
+                                  SigHashType().withForkId(),
+                                  spend_tx.vout[2].nValue));
         BOOST_CHECK(coinbaseKey.SignECDSA(hash, vchSig));
         vchSig.push_back(uint8_t(SIGHASH_ALL | SIGHASH_FORKID));
         invalid_with_csv_tx.vin[0].scriptSig = CScript() << vchSig << 101;


### PR DESCRIPTION
It now returns bool instead of uint256, and gets the output as parameter.

This is required for BIP341, because sighash calculation can fail there.