### PR TITLE
Refactor: thread ScriptExecutionData to SignatureHash.

### DIFF
--- a/src/bench/verify_script.cpp
+++ b/src/bench/verify_script.cpp
@@ -31,7 +31,7 @@ static void VerifyNestedIfScript(benchmark::Bench &bench) {
     bench.run([&] {
         auto stack_copy = stack;
         ScriptExecutionMetrics metrics = {};
-        ScriptExecutionData execdata = {};
+        ScriptExecutionData execdata{CScript()};
         ScriptError error;
         bool ret = EvalScript(stack_copy, script, 0, BaseSignatureChecker(),
                               metrics, execdata, &error);

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -23,9 +23,10 @@ class CTransaction;
 class uint256;
 
 template <class T>
-bool SignatureHash(uint256 &sighashOut, const CScript &scriptCode,
-                   const T &txTo, unsigned int nIn, SigHashType sigHashType,
-                   const Amount amount,
+bool SignatureHash(uint256 &sighashOut,
+                   const std::optional<ScriptExecutionData> &execdata,
+                   const CScript &scriptCode, const T &txTo, unsigned int nIn,
+                   SigHashType sigHashType, const Amount amount,
                    const PrecomputedTransactionData *cache = nullptr,
                    uint32_t flags = SCRIPT_ENABLE_SIGHASH_FORKID);
 
@@ -37,6 +38,7 @@ public:
 
     virtual bool CheckSig(const std::vector<uint8_t> &vchSigIn,
                           const std::vector<uint8_t> &vchPubKey,
+                          const std::optional<ScriptExecutionData> &execdata,
                           const CScript &scriptCode, uint32_t flags) const {
         return false;
     }
@@ -69,6 +71,7 @@ public:
     // The overridden functions are now final.
     bool CheckSig(const std::vector<uint8_t> &vchSigIn,
                   const std::vector<uint8_t> &vchPubKey,
+                  const std::optional<ScriptExecutionData> &execdata,
                   const CScript &scriptCode,
                   uint32_t flags) const final override;
     bool CheckLockTime(const CScriptNum &nLockTime) const final override;
@@ -89,7 +92,7 @@ static inline bool EvalScript(std::vector<std::vector<uint8_t>> &stack,
                               const BaseSignatureChecker &checker,
                               ScriptError *error = nullptr) {
     ScriptExecutionMetrics dummymetrics;
-    ScriptExecutionData dummyexecdata;
+    ScriptExecutionData dummyexecdata{script};
     return EvalScript(stack, script, flags, checker, dummymetrics,
                       dummyexecdata, error);
 }

--- a/src/script/script_exec_data.h
+++ b/src/script/script_exec_data.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_SCRIPT_SCRIPT_EXEC_DATA_H
 #define BITCOIN_SCRIPT_SCRIPT_EXEC_DATA_H
 
+#include <hash.h>
+#include <script/script.h>
 #include <uint256.h>
 
 /**
@@ -12,12 +14,41 @@
  * during script execution, e.g. for computing sig hashes.
  */
 struct ScriptExecutionData {
+    static constexpr uint32_t DEFAULT_CODESEP_POS = 0xffff'ffff;
+
     /**
      * Opcode position of the last executed OP_CODESEPARATOR.
-     * 
+     *
      * This allows signatures to commit to certain code paths.
      */
     uint32_t m_codeseparator_pos;
+
+    /**
+     * SHA256 of the (complete) script being executed, regardless of
+     * OP_CODESEPARATOR.
+     *
+     * - In plain scripts, this is the SHA256 of the scriptPubKey.
+     * - In P2SH, this is the SHA256 of the redeemScript.
+     * - In Tapscripts, this is the "tapleaf hash", calculated as defined in
+     *   BIP341: taggedhash_TapLeaf(version || compact_size(len(script)) ||
+     *                              script).
+     * - In Taproot, this entire struct would not be constructed.
+     */
+    uint256 m_executed_script_hash;
+
+    /**
+     * ScriptExecutionData with the SHA-256 of executed_script and as
+     * codeseparator position.
+     */
+    ScriptExecutionData(const CScript &executed_script,
+                        uint32_t codeseparator_pos = DEFAULT_CODESEP_POS) {
+        CSHA256()
+            .Write(executed_script.data(), executed_script.size())
+            .Finalize(m_executed_script_hash.begin());
+        m_codeseparator_pos = codeseparator_pos;
+    }
+
+    ScriptExecutionData() = delete;
 };
 
 #endif // BITCOIN_SCRIPT_SCRIPT_EXEC_DATA_H

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -31,6 +31,7 @@ public:
     /** Create a singular (non-script) signature. */
     virtual bool CreateSig(const SigningProvider &provider,
                            std::vector<uint8_t> &vchSig, const CKeyID &keyid,
+                           const std::optional<ScriptExecutionData> &execdata,
                            const CScript &scriptCode) const = 0;
 };
 
@@ -50,6 +51,7 @@ public:
     const BaseSignatureChecker &Checker() const override { return checker; }
     bool CreateSig(const SigningProvider &provider,
                    std::vector<uint8_t> &vchSig, const CKeyID &keyid,
+                   const std::optional<ScriptExecutionData> &execdata,
                    const CScript &scriptCode) const override;
 };
 

--- a/src/test/fuzz/script_sign.cpp
+++ b/src/test/fuzz/script_sign.cpp
@@ -146,8 +146,9 @@ void test_one_input(const std::vector<uint8_t> &buffer) {
                 } else {
                     address = CKeyID{ConsumeUInt160(fuzzed_data_provider)};
                 }
+                const ScriptExecutionData execdata{CScript()};
                 (void)signature_creator.CreateSig(
-                    provider, vch_sig, address,
+                    provider, vch_sig, address, std::optional(execdata),
                     ConsumeScript(fuzzed_data_provider));
             }
             std::map<COutPoint, Coin> coins;

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -23,8 +23,10 @@ static CScript sign_multisig(const CScript &scriptPubKey,
                              const std::vector<CKey> &keys,
                              const CMutableTransaction &tx, int whichIn) {
     uint256 hash;
-    BOOST_CHECK(SignatureHash(hash, scriptPubKey, CTransaction(tx), whichIn,
-                              SigHashType(), Amount::zero()));
+    BOOST_CHECK(SignatureHash(
+        hash, std::optional(ScriptExecutionData(scriptPubKey)),
+        scriptPubKey, CTransaction(tx), whichIn, SigHashType(),
+        Amount::zero()));
 
     CScript result;
     // CHECKMULTISIG bug workaround

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -341,8 +341,9 @@ public:
                  Amount amount = Amount::zero(),
                  uint32_t sigFlags = SCRIPT_ENABLE_SIGHASH_FORKID) {
         uint256 hash;
-        BOOST_CHECK(SignatureHash(hash, script, CTransaction(spendTx), 0,
-                                  sigHashType, amount, nullptr, sigFlags));
+        BOOST_CHECK(SignatureHash(
+            hash, std::optional(ScriptExecutionData(script)), script,
+            CTransaction(spendTx), 0, sigHashType, amount, nullptr, sigFlags));
         std::vector<uint8_t> vchSig = DoSignECDSA(key, hash, lenR, lenS);
         vchSig.push_back(static_cast<uint8_t>(sigHashType.getRawSigHashType()));
         DoPush(vchSig);
@@ -354,8 +355,9 @@ public:
                    Amount amount = Amount::zero(),
                    uint32_t sigFlags = SCRIPT_ENABLE_SIGHASH_FORKID) {
         uint256 hash;
-        BOOST_CHECK(SignatureHash(hash, script, CTransaction(spendTx), 0,
-                                  sigHashType, amount, nullptr, sigFlags));
+        BOOST_CHECK(SignatureHash(
+            hash, std::optional(ScriptExecutionData(script)), script,
+            CTransaction(spendTx), 0, sigHashType, amount, nullptr, sigFlags));
         std::vector<uint8_t> vchSig = DoSignSchnorr(key, hash);
         vchSig.push_back(static_cast<uint8_t>(sigHashType.getRawSigHashType()));
         DoPush(vchSig);
@@ -389,8 +391,9 @@ public:
         // This calculates a pubkey to verify with a given ECDSA transaction
         // signature.
         uint256 hash;
-        BOOST_CHECK(SignatureHash(hash, script, CTransaction(spendTx), 0,
-                                  sigHashType, amount, nullptr, sigFlags));
+        BOOST_CHECK(SignatureHash(hash, ScriptExecutionData(script), script,
+                                  CTransaction(spendTx), 0, sigHashType, amount,
+                                  nullptr, sigFlags));
 
         assert(rdata.size() <= 32);
         assert(sdata.size() <= 32);
@@ -2157,8 +2160,9 @@ static CScript sign_multisig(const CScript &scriptPubKey,
                              const std::vector<CKey> &keys,
                              const CTransaction &transaction) {
     uint256 hash;
-    BOOST_CHECK(SignatureHash(hash, scriptPubKey, transaction, 0, SigHashType(),
-                              Amount::zero()));
+    BOOST_CHECK(SignatureHash(
+        hash, std::optional(ScriptExecutionData(scriptPubKey)), scriptPubKey,
+        transaction, 0, SigHashType(), Amount::zero()));
 
     CScript result;
     //
@@ -2456,14 +2460,16 @@ BOOST_AUTO_TEST_CASE(script_combineSigs) {
     // A couple of partially-signed versions:
     std::vector<uint8_t> sig1;
     uint256 hash1;
-    BOOST_CHECK(SignatureHash(hash1, scriptPubKey, CTransaction(txTo), 0,
+    BOOST_CHECK(SignatureHash(hash1, ScriptExecutionData(scriptPubKey),
+                              scriptPubKey, CTransaction(txTo), 0,
                               SigHashType().withForkId(), Amount::zero()));
     BOOST_CHECK(keys[0].SignECDSA(hash1, sig1));
     sig1.push_back(SIGHASH_ALL | SIGHASH_FORKID);
     std::vector<uint8_t> sig2;
     uint256 hash2;
     BOOST_CHECK(SignatureHash(
-        hash2, scriptPubKey, CTransaction(txTo), 0,
+        hash2, ScriptExecutionData(scriptPubKey), scriptPubKey,
+        CTransaction(txTo), 0,
         SigHashType().withBaseType(BaseSigHashType::NONE).withForkId(),
         Amount::zero()));
     BOOST_CHECK(keys[1].SignECDSA(hash2, sig2));
@@ -2471,7 +2477,8 @@ BOOST_AUTO_TEST_CASE(script_combineSigs) {
     std::vector<uint8_t> sig3;
     uint256 hash3;
     BOOST_CHECK(SignatureHash(
-        hash3, scriptPubKey, CTransaction(txTo), 0,
+        hash3, ScriptExecutionData(scriptPubKey), scriptPubKey,
+        CTransaction(txTo), 0,
         SigHashType().withBaseType(BaseSigHashType::SINGLE).withForkId(),
         Amount::zero()));
     BOOST_CHECK(keys[2].SignECDSA(hash3, sig3));

--- a/src/test/sigcheckcount_tests.cpp
+++ b/src/test/sigcheckcount_tests.cpp
@@ -72,6 +72,7 @@ static class : public BaseSignatureChecker {
 
     bool CheckSig(const std::vector<uint8_t> &vchSigIn,
                   const std::vector<uint8_t> &vchPubKey,
+                  const std::optional<ScriptExecutionData> &execdata,
                   const CScript &scriptCode, uint32_t flags) const final {
         if (vchPubKey == badpub) {
             return false;
@@ -114,7 +115,7 @@ static void CheckEvalScript(const stacktype &original_stack,
         ScriptError err = ScriptError::UNKNOWN;
         stacktype stack{original_stack};
         ScriptExecutionMetrics metrics;
-        ScriptExecutionData execdata;
+        ScriptExecutionData execdata{script};
 
         bool r = EvalScript(stack, script, flags, dummysigchecker, metrics,
                             execdata, &err);
@@ -212,7 +213,7 @@ BOOST_AUTO_TEST_CASE(test_evalscript) {
     {
         stacktype stack{txsigschnorr};
         ScriptExecutionMetrics metrics;
-        ScriptExecutionData execdata;
+        ScriptExecutionData execdata{CScript()};
         metrics.nSigChecks = 12345;
         bool r = EvalScript(stack, CScript() << pub << OP_CHECKSIG,
                             SCRIPT_ENABLE_SIGHASH_FORKID, dummysigchecker,

--- a/src/test/sighash_bip341_tests.cpp
+++ b/src/test/sighash_bip341_tests.cpp
@@ -113,7 +113,7 @@ void CheckCodesepPos(const CScript &script,
     for (uint32_t flags : allflags) {
         BaseSignatureChecker sigchecker;
         ScriptExecutionMetrics metrics = {};
-        ScriptExecutionData execdata = {};
+        ScriptExecutionData execdata{CScript()};
         stacktype stack = {};
         bool r =
             EvalScript(stack, script, flags, sigchecker, metrics, execdata);

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -52,9 +52,10 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, TestChain100Setup) {
         // Sign:
         std::vector<uint8_t> vchSig;
         uint256 hash;
-        BOOST_CHECK(SignatureHash(hash, scriptPubKey, CTransaction(spends[i]),
-                                  0, SigHashType().withForkId(),
-                                  m_coinbase_txns[0]->vout[0].nValue));
+        BOOST_CHECK(SignatureHash(
+            hash, std::optional(ScriptExecutionData(scriptPubKey)),
+            scriptPubKey, CTransaction(spends[i]), 0,
+            SigHashType().withForkId(), m_coinbase_txns[0]->vout[0].nValue));
         BOOST_CHECK(coinbaseKey.SignECDSA(hash, vchSig));
         vchSig.push_back(uint8_t(SIGHASH_ALL | SIGHASH_FORKID));
         spends[i].vin[0].scriptSig << vchSig;
@@ -218,7 +219,9 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, TestChain100Setup) {
         std::vector<uint8_t> fundingVchSig;
         uint256 fundingSigHash;
         BOOST_CHECK(SignatureHash(
-            fundingSigHash, p2pk_scriptPubKey, CTransaction(funding_tx), 0,
+            fundingSigHash,
+            std::optional(ScriptExecutionData(p2pk_scriptPubKey)),
+            p2pk_scriptPubKey, CTransaction(funding_tx), 0,
             SigHashType().withForkId(), m_coinbase_txns[0]->vout[0].nValue));
         BOOST_CHECK(coinbaseKey.SignECDSA(fundingSigHash, fundingVchSig));
         fundingVchSig.push_back(uint8_t(SIGHASH_ALL | SIGHASH_FORKID));
@@ -346,10 +349,11 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, TestChain100Setup) {
         // Sign
         std::vector<uint8_t> vchSig;
         uint256 hash;
-        BOOST_CHECK(SignatureHash(hash, spend_tx.vout[1].scriptPubKey,
-                                  CTransaction(invalid_with_cltv_tx), 0,
-                                  SigHashType().withForkId(),
-                                  spend_tx.vout[1].nValue));
+        BOOST_CHECK(SignatureHash(
+            hash,
+            std::optional(ScriptExecutionData(spend_tx.vout[1].scriptPubKey)),
+            spend_tx.vout[1].scriptPubKey, CTransaction(invalid_with_cltv_tx),
+            0, SigHashType().withForkId(), spend_tx.vout[1].nValue));
         BOOST_CHECK(coinbaseKey.SignECDSA(hash, vchSig));
         vchSig.push_back(uint8_t(SIGHASH_ALL | SIGHASH_FORKID));
         invalid_with_cltv_tx.vin[0].scriptSig = CScript() << vchSig << 101;
@@ -392,10 +396,11 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, TestChain100Setup) {
         // Sign
         std::vector<uint8_t> vchSig;
         uint256 hash;
-        BOOST_CHECK(SignatureHash(hash, spend_tx.vout[2].scriptPubKey,
-                                  CTransaction(invalid_with_csv_tx), 0,
-                                  SigHashType().withForkId(),
-                                  spend_tx.vout[2].nValue));
+        BOOST_CHECK(SignatureHash(
+            hash,
+            std::optional(ScriptExecutionData(spend_tx.vout[2].scriptPubKey)),
+            spend_tx.vout[2].scriptPubKey, CTransaction(invalid_with_csv_tx), 0,
+            SigHashType().withForkId(), spend_tx.vout[2].nValue));
         BOOST_CHECK(coinbaseKey.SignECDSA(hash, vchSig));
         vchSig.push_back(uint8_t(SIGHASH_ALL | SIGHASH_FORKID));
         invalid_with_csv_tx.vin[0].scriptSig = CScript() << vchSig << 101;


### PR DESCRIPTION
ScriptExecutionData contains `codeseparator_pos` and `executed_script_hash`, which is required for the BIP341 sighash.