### PR TITLE
Rename OP_VER to OP_SCRIPTTYPE, add INVALID_OP_SCRIPTTYPE.

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -83,7 +83,6 @@ static void CleanupScriptCode(CScript &scriptCode,
 static bool IsOpcodeDisabled(opcodetype opcode, uint32_t flags) {
     switch (opcode) {
         case OP_RESERVED:
-        case OP_VER:
         case OP_VERIF:
         case OP_VERNOTIF:
         case OP_IFDUP:
@@ -261,6 +260,10 @@ bool EvalScript(std::vector<valtype> &stack, const CScript &script,
             // Some opcodes are disabled (CVE-2010-5137).
             if (IsOpcodeDisabled(opcode, flags)) {
                 return set_error(serror, ScriptError::DISABLED_OPCODE);
+            }
+
+            if (opcode == OP_SCRIPTTYPE) {
+                return set_error(serror, ScriptError::INVALID_OP_SCRIPTTYPE);
             }
 
             if (fExec && 0 <= opcode && opcode <= OP_PUSHDATA4) {

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -62,8 +62,8 @@ std::string GetOpName(opcodetype opcode) {
         // control
         case OP_NOP:
             return "OP_NOP";
-        case OP_VER:
-            return "OP_VER";
+        case OP_SCRIPTTYPE:
+            return "OP_SCRIPTTYPE";
         case OP_IF:
             return "OP_IF";
         case OP_NOTIF:

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -75,7 +75,7 @@ enum opcodetype {
 
     // control
     OP_NOP = 0x61,
-    OP_VER = 0x62,
+    OP_SCRIPTTYPE = 0x62,
     OP_IF = 0x63,
     OP_NOTIF = 0x64,
     OP_VERIF = 0x65,

--- a/src/script/script_error.cpp
+++ b/src/script/script_error.cpp
@@ -108,6 +108,8 @@ std::string ScriptErrorString(const ScriptError serror) {
             return "OP_NUM2BIN size limit exceeded";
         case ScriptError::SIGCHECKS_LIMIT_EXCEEDED:
             return "Validation resources exceeded (SigChecks)";
+        case ScriptError::INVALID_OP_SCRIPTTYPE:
+            return "Marker opcode OP_SCRIPTTYPE cannot be executed";
         case ScriptError::UNKNOWN:
         case ScriptError::ERROR_COUNT:
         default:

--- a/src/script/script_error.h
+++ b/src/script/script_error.h
@@ -85,6 +85,10 @@ enum class ScriptError {
     /* Auxiliary errors (unused by interpreter) */
     SIGCHECKS_LIMIT_EXCEEDED,
 
+    /* OP_SCRIPTTYPE should never be executed in an executed script, it's only a
+       marker */
+    INVALID_OP_SCRIPTTYPE,
+
     ERROR_COUNT,
 };
 

--- a/src/test/data/script_tests.json
+++ b/src/test/data/script_tests.json
@@ -38,8 +38,9 @@
 ["0", "IF 0x50 ENDIF 1", "", "DISABLED_OPCODE", "0x50 is disabled (even if not executed)"],
 ["0x51", "0x5f ADD 0x60 EQUAL", "", "OK", "0x51 through 0x60 push 1 through 16 onto stack"],
 ["1","NOP", "", "OK"],
-["0", "IF VER ELSE 1 ENDIF", "", "DISABLED_OPCODE", "VER disabled"],
 ["0", "IF RESERVED RESERVED1 RESERVED2 ELSE 1 ENDIF", "", "DISABLED_OPCODE", "RESERVED disabled"],
+
+["0", "IF SCRIPTTYPE ELSE 1 ENDIF", "", "INVALID_OP_SCRIPTTYPE", "Marker opcode OP_SCRIPTTYPE cannot occur in script"],
 
 ["1", "DUP IF ENDIF", "", "OK"],
 ["1", "IF 1 ENDIF", "", "OK"],
@@ -684,11 +685,12 @@
 ["1", "IF 0x50 ENDIF 1", "","DISABLED_OPCODE", "0x50 is disabled"],
 ["0x52", "0x5f ADD 0x60 EQUAL", "","EVAL_FALSE", "0x51 through 0x60 push 1 through 16 onto stack"],
 ["0","NOP", "","EVAL_FALSE",""],
-["1", "IF VER ELSE 1 ENDIF", "", "DISABLED_OPCODE", "VER non-functional"],
 ["0", "IF VERIF ELSE 1 ENDIF", "", "DISABLED_OPCODE", "VERIF illegal everywhere"],
 ["0", "IF ELSE 1 ELSE VERIF ENDIF", "", "DISABLED_OPCODE", "VERIF illegal everywhere"],
 ["0", "IF VERNOTIF ELSE 1 ENDIF", "", "DISABLED_OPCODE", "VERNOTIF illegal everywhere"],
 ["0", "IF ELSE 1 ELSE VERNOTIF ENDIF", "", "DISABLED_OPCODE", "VERNOTIF illegal everywhere"],
+
+["1", "IF SCRIPTTYPE ELSE 1 ENDIF", "", "INVALID_OP_SCRIPTTYPE", "Marker opcode OP_SCRIPTTYPE cannot occur in script"],
 
 ["1 IF", "1 ENDIF", "", "SIG_PUSHONLY", "IF/ENDIF can't span scriptSig/scriptPubKey; kept in case someone re-activates opcodes in sigScript"],
 ["1 IF 0 ENDIF", "1 ENDIF", "", "SIG_PUSHONLY"],
@@ -1834,7 +1836,8 @@
 
 ["","NOP10", "", "EVAL_FALSE"],
 
-["1","VER", "", "DISABLED_OPCODE", "OP_VER is disabled"],
+["1","SCRIPTTYPE", "", "INVALID_OP_SCRIPTTYPE", "Marker opcode OP_SCRIPTTYPE cannot occur in script"],
+
 ["1","VERIF", "", "DISABLED_OPCODE", "OP_VERIF is reserved"],
 ["1","VERNOTIF", "", "DISABLED_OPCODE", "OP_VERNOTIF is reserved"],
 ["1","RESERVED", "", "DISABLED_OPCODE", "OP_RESERVED is disabled"],
@@ -1961,7 +1964,7 @@
 ["NOP1 0x01 1", "HASH160 0x14 0xda1745e9b549bd0bfa1a569971c77eba30cd5a4b EQUAL", "", "SIG_PUSHONLY"],
 
 ["0 0x01 0x50", "HASH160 0x14 0xece424a6bb6ddf4db592c0faed60685047a361b1 EQUAL", "", "DISABLED_OPCODE", "OP_RESERVED in P2SH should fail"],
-["0 0x01 VER", "HASH160 0x14 0x0f4d7845db968f2a81b530b6f3c1d6246d4c7e01 EQUAL", "", "DISABLED_OPCODE", "OP_VER in P2SH should fail"],
+["0 0x01 SCRIPTTYPE", "HASH160 0x14 0x0f4d7845db968f2a81b530b6f3c1d6246d4c7e01 EQUAL", "", "INVALID_OP_SCRIPTTYPE", "OP_SCRIPTTYPE in P2SH should fail"],
 
 ["0x00", "'00' EQUAL", "", "EVAL_FALSE", "Basic OP_0 execution"],
 

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -94,6 +94,7 @@ static ScriptErrorDesc script_errors[] = {
     {ScriptError::INVALID_BITFIELD_SIZE, "BITFIELD_SIZE"},
     {ScriptError::INVALID_BIT_RANGE, "BIT_RANGE"},
     {ScriptError::INVALID_NUM2BIN_SIZE, "INVALID_NUM2BIN_SIZE"},
+    {ScriptError::INVALID_OP_SCRIPTTYPE, "INVALID_OP_SCRIPTTYPE"},
 };
 
 static std::string FormatScriptError(ScriptError err) {

--- a/test/functional/test_framework/script.py
+++ b/test/functional/test_framework/script.py
@@ -147,7 +147,7 @@ OP_16 = CScriptOp(0x60)
 
 # control
 OP_NOP = CScriptOp(0x61)
-OP_VER = CScriptOp(0x62)
+OP_SCRIPTTYPE = CScriptOp(0x62)
 OP_IF = CScriptOp(0x63)
 OP_NOTIF = CScriptOp(0x64)
 OP_VERIF = CScriptOp(0x65)
@@ -294,7 +294,7 @@ OPCODE_NAMES.update({
     OP_15: 'OP_15',
     OP_16: 'OP_16',
     OP_NOP: 'OP_NOP',
-    OP_VER: 'OP_VER',
+    OP_SCRIPTTYPE: 'OP_SCRIPTTYPE',
     OP_IF: 'OP_IF',
     OP_NOTIF: 'OP_NOTIF',
     OP_VERIF: 'OP_VERIF',


### PR DESCRIPTION
This marker opcode allows us to introduce new models of execution, such as Taproot.