### PR TITLE
Add CPubKey::AddScalar

### DIFF
--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -172,6 +172,12 @@ public:
                        const std::vector<uint8_t> &vchSig) const;
 
     /**
+     * Verify that this pubkey is the base point tweaked by tweak.
+     * Computes base + tweak*G and checks that it's equal to this.
+     */
+    bool AddScalar(CPubKey &result, const uint256 &scalar) const;
+
+    /**
      * Check whether a DER-serialized ECDSA signature is normalized (lower-S).
      */
     static bool

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -209,6 +209,7 @@ add_boost_unit_tests_to_suite(bitcoin test_bitcoin
 		skiplist_tests.cpp
 		streams_tests.cpp
 		sync_tests.cpp
+		taproot_tests.cpp
 		timedata_tests.cpp
 		torcontrol_tests.cpp
 		transaction_tests.cpp

--- a/src/test/taproot_tests.cpp
+++ b/src/test/taproot_tests.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2021 Logos Foundation
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <util/strencodings.h>
+
+#include <test/util/setup_common.h>
+
+#include <boost/test/unit_test.hpp>
+
+typedef std::vector<uint8_t> valtype;
+typedef std::vector<valtype> stacktype;
+
+BOOST_FIXTURE_TEST_SUITE(taproot_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(taproot_cpubkey_add_scalar) {
+    valtype vch_base, vch_tweaked;
+    uint256 tweak;
+    CPubKey pubkey_base, pubkey_tweaked, pubkey_result;
+
+    vch_base = ParseHex(
+        "020000000000000000000000000000000000000000000000000000000000000001");
+    // coincurve.PublicKey(bytes.fromhex('02' + '00'*31 + '01'))
+    //     .add(bytes.fromhex('0123456789abcdef' * 4)).format().hex()
+    vch_tweaked = ParseHex(
+        "032e3e15ea4cf7d0c88503a3d9d514ecd63443736a5907de89ba38f1d5d00ffe41");
+    tweak = uint256(ParseHex(
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"));
+    pubkey_base = CPubKey(vch_base.begin(), vch_base.end());
+    pubkey_tweaked = CPubKey(vch_tweaked.begin(), vch_tweaked.end());
+    BOOST_CHECK(pubkey_base.AddScalar(pubkey_result, tweak));
+    BOOST_CHECK_EQUAL(HexStr(pubkey_result), HexStr(pubkey_tweaked));
+
+    vch_base = ParseHex(
+        "030000000000000000000000000000000000000000000000000000000000000045");
+    vch_tweaked = ParseHex(
+        "021c2d2372cdb3accaaeb40ea9c96392df28d00f0aa503a42bd1edef117cba333c");
+    tweak = uint256(ParseHex(
+        "0707070707070707070707070707070707070707070707070707070707070707"));
+    pubkey_base = CPubKey(vch_base.begin(), vch_base.end());
+    pubkey_tweaked = CPubKey(vch_tweaked.begin(), vch_tweaked.end());
+    BOOST_CHECK(pubkey_base.AddScalar(pubkey_result, tweak));
+    BOOST_CHECK_EQUAL(HexStr(pubkey_result), HexStr(pubkey_tweaked));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This the base point tweaked by a tweak; in other words this + tweak*G.

This is required for Taproot, for verifying that the hash of the tapleaf combined with the base point results in the commitment.