### PR TITLE
Add VerifyTaprootCommitment

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -502,6 +502,7 @@ add_library(script
 	script/sign.cpp
 	script/signingprovider.cpp
 	script/standard.cpp
+	script/taproot.cpp
 )
 
 target_link_libraries(script common)

--- a/src/script/taproot.cpp
+++ b/src/script/taproot.cpp
@@ -1,0 +1,64 @@
+// Copyright (c) 2021 Logos Foundation
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <hash.h>
+#include <pubkey.h>
+#include <script/taproot.h>
+
+static const CHashWriter HASHER_TAPLEAF = TaggedHash("TapLeaf");
+static const CHashWriter HASHER_TAPBRANCH = TaggedHash("TapBranch");
+static const CHashWriter HASHER_TAPTWEAK = TaggedHash("TapTweak");
+
+bool VerifyTaprootCommitment(uint256 &tapleaf_hash,
+                             const valtype &control_block,
+                             const valtype &commitment,
+                             const CScript &exec_script) {
+    const int path_len = (control_block.size() - TAPROOT_CONTROL_BASE_SIZE) /
+                         TAPROOT_CONTROL_NODE_SIZE;
+
+    // Calculate merkle root
+    CHashWriter tapleaf_hasher = HASHER_TAPLEAF;
+    tapleaf_hasher << uint8_t(control_block[0] & TAPROOT_LEAF_MASK)
+                   << exec_script;
+    tapleaf_hash = tapleaf_hasher.GetSHA256();
+    uint256 merkle_hash = tapleaf_hash;
+    const uint8_t *control_nodes =
+        control_block.data() + TAPROOT_CONTROL_BASE_SIZE;
+    for (int i = 0; i < path_len; ++i) {
+        CHashWriter ss_branch = HASHER_TAPBRANCH;
+        Span<const uint8_t> node(control_nodes + TAPROOT_CONTROL_NODE_SIZE * i,
+                                 TAPROOT_CONTROL_NODE_SIZE);
+        if (std::lexicographical_compare(merkle_hash.begin(), merkle_hash.end(),
+                                         node.begin(), node.end())) {
+            ss_branch << merkle_hash << node;
+        } else {
+            ss_branch << node << merkle_hash;
+        }
+        merkle_hash = ss_branch.GetSHA256();
+    }
+
+    // Extract internal pubkey from the control block
+    // Note: We're not using the X-only pubkeys, unlike as in Bitcoin Core.
+    // There, commitment is 32 bytes, not 33 and the parity of the commitment is
+    // then encoded in the first bit of the first byte of the control block.
+    // We don't need to do that as we're using 33 byte pubkeys. Instead, we just
+    // encode the parity of the internal pubkey in that first bit of the first
+    // byte of the control block.
+    valtype vch_p(control_block.begin(),
+                  control_block.begin() + TAPROOT_CONTROL_BASE_SIZE);
+    // Parity of internal pubkey is encoded in the first bit
+    vch_p[0] = vch_p[0] & 1 ? 0x03 : 0x02;
+    const CPubKey p{vch_p};
+    const uint256 tweak_hash =
+        (CHashWriter(HASHER_TAPTWEAK) << MakeSpan(p) << merkle_hash)
+            .GetSHA256();
+
+    // Verify commitment matches
+    const CPubKey q{commitment};
+    CPubKey q_expected;
+    if (!p.AddScalar(q_expected, tweak_hash)) {
+        return false;
+    }
+    return q == q_expected;
+}

--- a/src/script/taproot.h
+++ b/src/script/taproot.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2021 Logos Foundation
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_SCRIPT_TAPROOT_H
+#define BITCOIN_SCRIPT_TAPROOT_H
+
+#include <script/script.h>
+#include <uint256.h>
+
+typedef std::vector<uint8_t> valtype;
+
+static constexpr uint8_t TAPROOT_LEAF_MASK = 0xfe;
+static constexpr uint8_t TAPROOT_LEAF_TAPSCRIPT = 0xc0;
+static constexpr size_t TAPROOT_CONTROL_BASE_SIZE = 33;
+static constexpr size_t TAPROOT_CONTROL_NODE_SIZE = 32;
+static constexpr size_t TAPROOT_CONTROL_MAX_NODE_COUNT = 128;
+static constexpr size_t TAPROOT_CONTROL_MAX_SIZE =
+    TAPROOT_CONTROL_BASE_SIZE +
+    TAPROOT_CONTROL_NODE_SIZE * TAPROOT_CONTROL_MAX_NODE_COUNT;
+
+/**
+ * Verifies that the control block proves that script is part of the commitment.
+ *
+ * - tapleaf_hash: Output; the tapleaf hash of script.
+ * - control_block: Must have length 33 + 32 * n.
+ *   First byte is (leaf version | parity of internal_pubkey), next 32 bytes are
+ *   the X-coordinate of internal_pubkey, and then up to
+ *   TAPROOT_CONTROL_MAX_NODE_COUNT nodes of each 32 bytes.
+ * - commitment: Public key that has been committed to.
+ * - script: Script we are proving inclusion in commitment for.
+ *
+ * Note: The length requirements on control_block and commitment have to be
+ * upheld by the caller.
+ */
+bool VerifyTaprootCommitment(uint256 &tapleaf_hash,
+                             const valtype &control_block,
+                             const valtype &commitment, const CScript &script);
+
+#endif // BITCOIN_SCRIPT_TAPROOT_H

--- a/src/test/taproot_tests.cpp
+++ b/src/test/taproot_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <script/taproot.h>
 #include <util/strencodings.h>
 
 #include <test/util/setup_common.h>
@@ -41,6 +42,211 @@ BOOST_AUTO_TEST_CASE(taproot_cpubkey_add_scalar) {
     pubkey_tweaked = CPubKey(vch_tweaked.begin(), vch_tweaked.end());
     BOOST_CHECK(pubkey_base.AddScalar(pubkey_result, tweak));
     BOOST_CHECK_EQUAL(HexStr(pubkey_result), HexStr(pubkey_tweaked));
+}
+
+/**
+ * The control blocks have been generated using these Python functions, based
+ * on the Python code in BIP341:
+ * ```
+ * from dataclasses import dataclass
+ * from typing import List, Union
+ *
+ * from coincurve import PrivateKey, PublicKey
+ * import hashlib
+ *
+ * @dataclass
+ * class ScriptLeaf:
+ *     leaf_version: int
+ *     script: bytes
+ *
+ * @dataclass
+ * class ScriptBranch:
+ *     left: Union['ScriptBranch', ScriptLeaf]
+ *     right: Union['ScriptBranch', ScriptLeaf]
+ *
+ * @dataclass
+ * class TreeResult:
+ *     items: List['ResultItem']
+ *     hash: bytes
+ *
+ * @dataclass
+ * class ResultItem:
+ *     leaf: ScriptLeaf
+ *     path: bytes
+ *
+ * def tagged_hash(tag: str, data: bytes) -> bytes:
+ *     tag_hash = hashlib.sha256(tag.encode()).digest()
+ *     return hashlib.sha256(tag_hash + tag_hash + data).digest()
+ *
+ * def taproot_tweak_pubkey(pubkey: PublicKey, tweak_hash: bytes) -> PublicKey:
+ *     t = tagged_hash("TapTweak", pubkey.format() + tweak_hash)
+ *     return pubkey.add(t)
+ *
+ * def ser_script(script: bytes) -> bytes:
+ *     if len(script) < 0xfd:
+ *         return bytes([len(script)]) + script
+ *     elif len(script) <= 0xffff:
+ *         return b'\xfd' + len(script).to_bytes(2, 'little') + script
+ *     else:
+ *         raise ValueError('script too long')
+ *
+ * def taproot_tree_helper(script_tree: Union[ScriptBranch, ScriptLeaf]) -> \
+ *         TreeResult:
+ *     if isinstance(script_tree, ScriptLeaf):
+ *         h = tagged_hash("TapLeaf", bytes([script_tree.leaf_version]) +
+ *                         ser_script(script_tree.script))
+ *         return TreeResult(items=[ResultItem(script_tree, bytes())], hash=h)
+ *     left_result = taproot_tree_helper(script_tree.left)
+ *     right_result = taproot_tree_helper(script_tree.right)
+ *     ret = [ResultItem(item.leaf, item.path + right_result.hash)
+ *            for item in left_result.items] + \
+ *           [ResultItem(item.leaf, item.path + left_result.hash)
+ *            for item in right_result.items]
+ *     if right_result.hash < left_result.hash:
+ *         left_hash, right_hash = right_result.hash, left_result.hash
+ *     else:
+ *         left_hash, right_hash = left_result.hash, right_result.hash
+ *     return TreeResult(ret, tagged_hash("TapBranch", left_hash + right_hash))
+ *
+ * def taproot_output_script(
+ *         internal_pubkey: PublicKey,
+ *         script_tree: Union[None, ScriptBranch, ScriptLeaf]) -> bytes:
+ *     if script_tree is None:
+ *         h = bytes()
+ *     else:
+ *         h = taproot_tree_helper(script_tree).hash
+ *     output_pubkey = taproot_tweak_pubkey(internal_pubkey, h)
+ *     return bytes([]) + output_pubkey.format()
+ *
+ * def taproot_sign_script(internal_pubkey: PublicKey,
+ *                         script_tree: Union[None, ScriptBranch, ScriptLeaf],
+ *                         script_num: int,
+ *                         inputs: List[bytes]) -> List[bytes]:
+ *     tree_result = taproot_tree_helper(script_tree)
+ *     item = tree_result.items[script_num]
+ *     pubkey_ser = internal_pubkey.format()
+ *     parity = int(pubkey_ser[0] == 3)
+ *     pubkey_data = bytes([item.leaf.leaf_version | parity]) + pubkey_ser[1:]
+ *     return inputs + [item.leaf.script, pubkey_data + item.path]
+ * ```
+ */
+BOOST_AUTO_TEST_CASE(verify_taproot_commitment_1) {
+    // Test taproot commitment for a merkle tree of only one script.
+    CScript script = CScript() << 12 << 5 << OP_ADD << 17 << OP_EQUAL;
+    valtype program_pubkey = ParseHex(
+        "03f4d8f35fc9bd150aa9071471adaef4edbfcabc7b29c2a80b6564b0b7a06318f2");
+    valtype control_block = ParseHex(
+        "0079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798");
+    uint256 taproot_leaf;
+    BOOST_CHECK(VerifyTaprootCommitment(taproot_leaf, control_block,
+                                        program_pubkey, script));
+    std::vector<uint8_t> expected_taproot_leaf = ParseHex(
+        "d391a5068704b630ec4a50f2ba1e48aab89696aee831f1c4513034bc3a999165");
+    BOOST_CHECK_EQUAL(taproot_leaf, uint256(expected_taproot_leaf));
+}
+
+BOOST_AUTO_TEST_CASE(verify_taproot_commitment_1_leaf_version) {
+    // Test taproot commitment for a merkle tree of only one script, with leaf
+    // version 0xe8.
+    CScript script = CScript() << 1 << 5 << OP_ADD << 6 << OP_EQUAL;
+    valtype program_pubkey = ParseHex(
+        "0311197854872410770e5d13edd8277bdc2c262026dcd3089c3a7cbe1c5f564270");
+    valtype control_block = ParseHex(
+        "e8c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5");
+    uint256 taproot_leaf;
+    BOOST_CHECK(VerifyTaprootCommitment(taproot_leaf, control_block,
+                                        program_pubkey, script));
+    std::vector<uint8_t> expected_taproot_leaf = ParseHex(
+        "e9bcbe4f6876670fe71704fd7af6b058316b5b4dd0dbf44988078cf0d7d26971");
+    BOOST_CHECK_EQUAL(taproot_leaf, uint256(expected_taproot_leaf));
+}
+
+BOOST_AUTO_TEST_CASE(verify_taproot_commitment_2) {
+    // Test taproot commitment for a merkle tree of two scripts with different
+    // leaf versions.
+    CScript script1 = CScript() << 2 << 3 << OP_ADD << 5 << OP_EQUAL;
+    CScript script2 = CScript() << 7 << 2 << OP_ADD << 9 << OP_EQUAL;
+    valtype program_pubkey = ParseHex(
+        "02b908223769e60046dee140a788fa96977012033adcfa8e328fa8c98fa3a3feba");
+    valtype control_block1 = ParseHex(
+        "fef9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9e82b"
+        "65cb9d7df2c20ffc76492b0c1f11bfeafc4df63344446d3b07d3327ffce9");
+    valtype control_block2 = ParseHex(
+        "02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f91cba"
+        "0b8238d48ff30e70971c56553ec181d4df06262ff9345043b44df0c92506");
+    uint256 taproot_leaf;
+    BOOST_CHECK(VerifyTaprootCommitment(taproot_leaf, control_block1,
+                                        program_pubkey, script1));
+    std::vector<uint8_t> expected_taproot_leaf = ParseHex(
+        "1cba0b8238d48ff30e70971c56553ec181d4df06262ff9345043b44df0c92506");
+    BOOST_CHECK_EQUAL(taproot_leaf, uint256(expected_taproot_leaf));
+    BOOST_CHECK(!VerifyTaprootCommitment(taproot_leaf, control_block2,
+                                         program_pubkey, script1));
+    BOOST_CHECK(!VerifyTaprootCommitment(taproot_leaf, control_block1,
+                                         program_pubkey, script2));
+    BOOST_CHECK(VerifyTaprootCommitment(taproot_leaf, control_block2,
+                                        program_pubkey, script2));
+    expected_taproot_leaf = ParseHex(
+        "e82b65cb9d7df2c20ffc76492b0c1f11bfeafc4df63344446d3b07d3327ffce9");
+    BOOST_CHECK_EQUAL(taproot_leaf, uint256(expected_taproot_leaf));
+}
+
+BOOST_AUTO_TEST_CASE(verify_taproot_commitment_3) {
+    /** Test taproot commitment for this merkle tree:
+     *             /\
+     *            /  \
+     *           /\ script3
+     *          /  \
+     *         /    \
+     *    script1  script2
+     */
+    CScript script1 = CScript() << 3 << 5 << OP_ADD << 8 << OP_EQUAL;
+    CScript script2 = CScript() << valtype{1, 2} << valtype{3} << OP_CAT
+                                << valtype{1, 2, 3} << OP_EQUAL;
+    CScript script3 = CScript() << OP_1;
+    valtype program_pubkey = ParseHex(
+        "0205e25701c5ba0e9549c9d3b3d68446ba0c2820cd5c6df627c4e171a8707d3197");
+    valtype control_block1 = ParseHex(
+        "01fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556d81a"
+        "eb54b742dd72fb69749163babdba30cca1b5afd4981353810862141c6e2f8fe98416ae"
+        "edc4ff4bdd55d79dd3e5399c9c2b1d2d2beea8c300c2ba262c5bbc");
+    valtype control_block2 = ParseHex(
+        "01fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a146029755677bf"
+        "ee7828dd0847e3d62ca232f39db7d2074cb06fd8120f8564a7bd15a912b68fe98416ae"
+        "edc4ff4bdd55d79dd3e5399c9c2b1d2d2beea8c300c2ba262c5bbc");
+    valtype control_block3 = ParseHex(
+        "01fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a14602975567aa2"
+        "675f80f547eb9dc2166a3b43dc9aabcd316d7a7e372094b2607da9a0a8eb");
+    uint256 taproot_leaf;
+    BOOST_CHECK(VerifyTaprootCommitment(taproot_leaf, control_block1,
+                                        program_pubkey, script1));
+    std::vector<uint8_t> expected_taproot_leaf = ParseHex(
+        "77bfee7828dd0847e3d62ca232f39db7d2074cb06fd8120f8564a7bd15a912b6");
+    BOOST_CHECK_EQUAL(taproot_leaf, uint256(expected_taproot_leaf));
+    BOOST_CHECK(!VerifyTaprootCommitment(taproot_leaf, control_block2,
+                                         program_pubkey, script1));
+    BOOST_CHECK(!VerifyTaprootCommitment(taproot_leaf, control_block3,
+                                         program_pubkey, script1));
+
+    BOOST_CHECK(!VerifyTaprootCommitment(taproot_leaf, control_block1,
+                                         program_pubkey, script2));
+    BOOST_CHECK(VerifyTaprootCommitment(taproot_leaf, control_block2,
+                                        program_pubkey, script2));
+    expected_taproot_leaf = ParseHex(
+        "d81aeb54b742dd72fb69749163babdba30cca1b5afd4981353810862141c6e2f");
+    BOOST_CHECK_EQUAL(taproot_leaf, uint256(expected_taproot_leaf));
+    BOOST_CHECK(!VerifyTaprootCommitment(taproot_leaf, control_block3,
+                                         program_pubkey, script2));
+
+    BOOST_CHECK(!VerifyTaprootCommitment(taproot_leaf, control_block1,
+                                         program_pubkey, script3));
+    BOOST_CHECK(!VerifyTaprootCommitment(taproot_leaf, control_block2,
+                                         program_pubkey, script3));
+    BOOST_CHECK(VerifyTaprootCommitment(taproot_leaf, control_block3,
+                                        program_pubkey, script3));
+    expected_taproot_leaf = ParseHex(
+        "8fe98416aeedc4ff4bdd55d79dd3e5399c9c2b1d2d2beea8c300c2ba262c5bbc");
+    BOOST_CHECK_EQUAL(taproot_leaf, uint256(expected_taproot_leaf));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This verifies a given script is part of the given Taproot commitment. It's required for implementing Taproot as output type.

Note: VerifyTaprootCommitment requires certain length invariants to be upheld, this has to be ensured by the caller.