### PR TITLE
Add SCRIPT_REQUIRE_TAPROOT_SIGHASH

### DIFF
--- a/src/script/script_error.cpp
+++ b/src/script/script_error.cpp
@@ -110,6 +110,8 @@ std::string ScriptErrorString(const ScriptError serror) {
             return "Validation resources exceeded (SigChecks)";
         case ScriptError::INVALID_OP_SCRIPTTYPE:
             return "Marker opcode OP_SCRIPTTYPE cannot be executed";
+        case ScriptError::TAPROOT_MUST_USE_BIP341_SIGHASH:
+            return "Taproot key path signatures must use SIGHASH_BIP341";
         case ScriptError::UNKNOWN:
         case ScriptError::ERROR_COUNT:
         default:

--- a/src/script/script_error.h
+++ b/src/script/script_error.h
@@ -89,6 +89,10 @@ enum class ScriptError {
        marker */
     INVALID_OP_SCRIPTTYPE,
 
+    /* Key spend path (spending without revealing the script) for Taproot must
+       use BIP341 sighash */
+    TAPROOT_MUST_USE_BIP341_SIGHASH,
+
     ERROR_COUNT,
 };
 

--- a/src/script/script_flags.h
+++ b/src/script/script_flags.h
@@ -48,6 +48,10 @@ enum {
     // Note: The Segwit Recovery feature is a (currently moot) exception to
     // VERIFY_INPUT_SIGCHECKS
     SCRIPT_VERIFY_INPUT_SIGCHECKS = (1U << 22),
+
+    // Require BIP341 sighash for key spend path (spending without revealing the
+    // script) in Taproot
+    SCRIPT_REQUIRE_BIP341_SIGHASH = (1U << 23),
 };
 
 #endif // BITCOIN_SCRIPT_SCRIPT_FLAGS_H

--- a/src/script/sigencoding.cpp
+++ b/src/script/sigencoding.cpp
@@ -216,6 +216,10 @@ static bool CheckSighashEncoding(const valtype &vchSig, uint32_t flags,
     }
 
     SigHashType sigHashType = GetHashType(vchSig);
+    // For Taproot key spend path
+    if ((flags & SCRIPT_REQUIRE_BIP341_SIGHASH) && !sigHashType.hasBIP341()) {
+        return set_error(serror, ScriptError::TAPROOT_MUST_USE_BIP341_SIGHASH);
+    }
     bool usesForkId = sigHashType.hasForkId() || sigHashType.hasBIP341();
     bool forkIdEnabled = flags & SCRIPT_ENABLE_SIGHASH_FORKID;
     if (!forkIdEnabled && usesForkId) {

--- a/src/test/schnorr_tests.cpp
+++ b/src/test/schnorr_tests.cpp
@@ -93,9 +93,14 @@ BOOST_AUTO_TEST_CASE(opcodes_random_flags) {
     for (int i = 0; i < 4096; i++) {
         uint32_t flags = lcg.next();
 
-        const bool hasForkId = (flags & SCRIPT_ENABLE_SIGHASH_FORKID) != 0;
-        const SigHashType sigHashType = SigHashType().withAlgorithm(
-            hasForkId ? SIGHASH_FORKID : SIGHASH_LEGACY);
+        SigHashType sigHashType = SigHashType();
+        if (flags & SCRIPT_REQUIRE_BIP341_SIGHASH) {
+            // Prevent invalid flag combinations
+            flags |= SCRIPT_ENABLE_SIGHASH_FORKID;
+            sigHashType = sigHashType.withBIP341();
+        } else if (flags & SCRIPT_ENABLE_SIGHASH_FORKID) {
+            sigHashType = sigHashType.withForkId();
+        }
 
         // Prepare 65-byte transaction sigs with right hashtype byte.
         valtype DER64_with_hashtype = SignatureWithHashType(DER64, sigHashType);

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -95,6 +95,8 @@ static ScriptErrorDesc script_errors[] = {
     {ScriptError::INVALID_BIT_RANGE, "BIT_RANGE"},
     {ScriptError::INVALID_NUM2BIN_SIZE, "INVALID_NUM2BIN_SIZE"},
     {ScriptError::INVALID_OP_SCRIPTTYPE, "INVALID_OP_SCRIPTTYPE"},
+    {ScriptError::TAPROOT_MUST_USE_BIP341_SIGHASH,
+     "TAPROOT_MUST_USE_BIP341_SIGHASH"},
 };
 
 static std::string FormatScriptError(ScriptError err) {

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -466,9 +466,10 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, TestChain100Setup) {
 
         // This should be valid under all script flags that support our sighash
         // convention.
-        ValidateCheckInputsForAllFlags(
-            CTransaction(tx), SCRIPT_ENABLE_REPLAY_PROTECTION,
-            SCRIPT_ENABLE_SIGHASH_FORKID, true, 2);
+        ValidateCheckInputsForAllFlags(CTransaction(tx),
+                                       SCRIPT_ENABLE_REPLAY_PROTECTION |
+                                           SCRIPT_REQUIRE_BIP341_SIGHASH,
+                                       SCRIPT_ENABLE_SIGHASH_FORKID, true, 2);
 
         {
             // Try checking this valid transaction with sigchecks limiter


### PR DESCRIPTION
This flag is required for verifying signatures for the Taproot key spend path (spending without revealing the script).