### PR TITLE
Add SCRIPT_REQUIRE_TAPROOT_SIGNATURES

### DIFF
--- a/src/script/script_error.cpp
+++ b/src/script/script_error.cpp
@@ -110,6 +110,10 @@ std::string ScriptErrorString(const ScriptError serror) {
             return "Validation resources exceeded (SigChecks)";
         case ScriptError::INVALID_OP_SCRIPTTYPE:
             return "Marker opcode OP_SCRIPTTYPE cannot be executed";
+        case ScriptError::TAPROOT_MUST_USE_BIP341_SIGHASH:
+            return "Taproot key spend signatures must use SIGHASH_BIP341";
+        case ScriptError::TAPROOT_MUST_USE_SCHNORR_SIGS:
+            return "Taproot key spend signatures must be Schnorr signatures";
         case ScriptError::UNKNOWN:
         case ScriptError::ERROR_COUNT:
         default:

--- a/src/script/script_error.h
+++ b/src/script/script_error.h
@@ -89,6 +89,11 @@ enum class ScriptError {
        marker */
     INVALID_OP_SCRIPTTYPE,
 
+    /* Key spend path for Taproot must use BIP341 sighash */
+    TAPROOT_MUST_USE_BIP341_SIGHASH,
+    /* Key spend path for Taproot must Schnorr signatures */
+    TAPROOT_MUST_USE_SCHNORR_SIGS,
+
     ERROR_COUNT,
 };
 

--- a/src/script/script_flags.h
+++ b/src/script/script_flags.h
@@ -11,6 +11,11 @@
 enum {
     SCRIPT_VERIFY_NONE = 0,
 
+    // Require BIP341 sighash and Schnorr signatures for key spend path
+    // (spending without revealing the script) in Taproot.
+    // Only used for checking signatures, not during script execution.
+    SCRIPT_REQUIRE_TAPROOT_SIGNATURES = (1U << 0),
+
     // Discourage use of NOPs reserved for upgrades (NOP1-10)
     //
     // Provided so that nodes can avoid accepting or mining transactions

--- a/src/test/checkdatasig_tests.cpp
+++ b/src/test/checkdatasig_tests.cpp
@@ -140,6 +140,8 @@ BOOST_AUTO_TEST_CASE(checkdatasig_test) {
     MMIXLinearCongruentialGenerator lcg;
     for (int i = 0; i < 4096; i++) {
         uint32_t flags = lcg.next();
+        // Flag cannot occur in script execution, only in Taproot key spend
+        flags &= ~SCRIPT_REQUIRE_TAPROOT_SIGNATURES;
 
         // Since strict encoding is enforced, hybrid keys are invalid.
         CheckError(flags, {{}, message, pubkeyH}, script,

--- a/src/test/schnorr_tests.cpp
+++ b/src/test/schnorr_tests.cpp
@@ -92,6 +92,8 @@ BOOST_AUTO_TEST_CASE(opcodes_random_flags) {
     MMIXLinearCongruentialGenerator lcg(1234);
     for (int i = 0; i < 4096; i++) {
         uint32_t flags = lcg.next();
+        // Flag cannot occur in script execution, only in Taproot key spend
+        flags &= ~SCRIPT_REQUIRE_TAPROOT_SIGNATURES;
 
         const bool hasForkId = (flags & SCRIPT_ENABLE_SIGHASH_FORKID) != 0;
         const SigHashType sigHashType = SigHashType().withAlgorithm(

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -95,6 +95,10 @@ static ScriptErrorDesc script_errors[] = {
     {ScriptError::INVALID_BIT_RANGE, "BIT_RANGE"},
     {ScriptError::INVALID_NUM2BIN_SIZE, "INVALID_NUM2BIN_SIZE"},
     {ScriptError::INVALID_OP_SCRIPTTYPE, "INVALID_OP_SCRIPTTYPE"},
+    {ScriptError::TAPROOT_MUST_USE_BIP341_SIGHASH,
+     "TAPROOT_MUST_USE_BIP341_SIGHASH"},
+    {ScriptError::TAPROOT_MUST_USE_SCHNORR_SIGS,
+     "TAPROOT_MUST_USE_SCHNORR_SIGS"},
 };
 
 static std::string FormatScriptError(ScriptError err) {

--- a/src/test/sigencoding_tests.cpp
+++ b/src/test/sigencoding_tests.cpp
@@ -21,10 +21,16 @@ static valtype SignatureWithHashType(valtype vchSig, SigHashType sigHash) {
 static void CheckSignatureEncodingWithSigHashType(const valtype &vchSig,
                                                   uint32_t flags) {
     ScriptError err = ScriptError::OK;
-    BOOST_CHECK(CheckDataSignatureEncoding(vchSig, flags, &err));
 
     const bool hasForkId = (flags & SCRIPT_ENABLE_SIGHASH_FORKID) != 0;
+    // isTaproot requires Schnorr sigs and BIP341 sighash
+    const bool isTaproot = (flags & SCRIPT_REQUIRE_TAPROOT_SIGNATURES) != 0;
     const bool is64 = (vchSig.size() == 64);
+
+    // isTaproot is never true for OP_CHECKDATASIG, but we test it anyway to
+    // make sure we don't introduce weird behavior
+    BOOST_CHECK_EQUAL(CheckDataSignatureEncoding(vchSig, flags, &err),
+                      !isTaproot || is64);
 
     std::vector<BaseSigHashType> allBaseTypes{
         BaseSigHashType::ALL, BaseSigHashType::NONE, BaseSigHashType::SINGLE};
@@ -47,13 +53,18 @@ static void CheckSignatureEncodingWithSigHashType(const valtype &vchSig,
     }
 
     for (const SigHashType &sigHash : sigHashes) {
-        // Check the signature with the proper forkid flag.
+        // isTaproot requires Schnorr sigs and BIP341 sighash
+        const bool expectedValid =
+            isTaproot ? is64 && sigHash.hasBIP341() : true;
         valtype validSig = SignatureWithHashType(vchSig, sigHash);
-        BOOST_CHECK(CheckTransactionSignatureEncoding(validSig, flags, &err));
-        BOOST_CHECK_EQUAL(!is64, CheckTransactionECDSASignatureEncoding(
-                                     validSig, flags, &err));
-        BOOST_CHECK_EQUAL(is64, CheckTransactionSchnorrSignatureEncoding(
-                                    validSig, flags, &err));
+        BOOST_CHECK_EQUAL(expectedValid, CheckTransactionSignatureEncoding(
+                                             validSig, flags, &err));
+        BOOST_CHECK_EQUAL(
+            !is64 && expectedValid,
+            CheckTransactionECDSASignatureEncoding(validSig, flags, &err));
+        BOOST_CHECK_EQUAL(
+            is64 && expectedValid,
+            CheckTransactionSchnorrSignatureEncoding(validSig, flags, &err));
 
         // If we have strict encoding, we prevent the use of undefined flags.
         std::array<SigHashType, 5> undefSigHashes{
@@ -67,15 +78,20 @@ static void CheckSignatureEncodingWithSigHashType(const valtype &vchSig,
             valtype undefSighash = SignatureWithHashType(vchSig, undefSigHash);
             BOOST_CHECK(
                 !CheckTransactionSignatureEncoding(undefSighash, flags, &err));
-            BOOST_CHECK(err == ScriptError::SIG_HASHTYPE);
-            BOOST_CHECK(!CheckTransactionECDSASignatureEncoding(
-                                  undefSighash, flags, &err));
-            BOOST_CHECK(err == (is64 ? ScriptError::SIG_BADLENGTH
-                                        : ScriptError::SIG_HASHTYPE));
-            BOOST_CHECK(!CheckTransactionSchnorrSignatureEncoding(
-                                  undefSighash, flags, &err));
-            BOOST_CHECK(err == (!is64 ? ScriptError::SIG_NONSCHNORR
-                                        : ScriptError::SIG_HASHTYPE));
+            BOOST_CHECK_EQUAL(err,
+                              isTaproot && !is64
+                                  ? ScriptError::TAPROOT_MUST_USE_SCHNORR_SIGS
+                                  : ScriptError::SIG_HASHTYPE);
+            BOOST_CHECK(!CheckTransactionECDSASignatureEncoding(undefSighash,
+                                                                flags, &err));
+            BOOST_CHECK_EQUAL(
+                err, isTaproot ? ScriptError::TAPROOT_MUST_USE_SCHNORR_SIGS
+                     : is64    ? ScriptError::SIG_BADLENGTH
+                               : ScriptError::SIG_HASHTYPE);
+            BOOST_CHECK(!CheckTransactionSchnorrSignatureEncoding(undefSighash,
+                                                                  flags, &err));
+            BOOST_CHECK_EQUAL(err, !is64 ? ScriptError::SIG_NONSCHNORR
+                                         : ScriptError::SIG_HASHTYPE);
         }
 
         // If we check strict encoding, then invalid forkid is an error.
@@ -85,20 +101,26 @@ static void CheckSignatureEncodingWithSigHashType(const valtype &vchSig,
 
         BOOST_CHECK(
             !CheckTransactionSignatureEncoding(invalidSig, flags, &err));
-        BOOST_CHECK(err == (hasForkId ? ScriptError::MUST_USE_FORKID
-                                        : ScriptError::ILLEGAL_FORKID));
+        BOOST_CHECK_EQUAL(
+            err, isTaproot
+                     ? (is64 ? ScriptError::TAPROOT_MUST_USE_BIP341_SIGHASH
+                             : ScriptError::TAPROOT_MUST_USE_SCHNORR_SIGS)
+                     : (hasForkId ? ScriptError::MUST_USE_FORKID
+                                  : ScriptError::ILLEGAL_FORKID));
         BOOST_CHECK(
             !CheckTransactionECDSASignatureEncoding(invalidSig, flags, &err));
-        BOOST_CHECK(err == (is64
-                                ? ScriptError::SIG_BADLENGTH
-                                : hasForkId ? ScriptError::MUST_USE_FORKID
-                                            : ScriptError::ILLEGAL_FORKID));
+        BOOST_CHECK_EQUAL(err, isTaproot
+                                   ? ScriptError::TAPROOT_MUST_USE_SCHNORR_SIGS
+                               : is64      ? ScriptError::SIG_BADLENGTH
+                               : hasForkId ? ScriptError::MUST_USE_FORKID
+                                           : ScriptError::ILLEGAL_FORKID);
         BOOST_CHECK(
             !CheckTransactionSchnorrSignatureEncoding(invalidSig, flags, &err));
-        BOOST_CHECK(err == (!is64
-                                ? ScriptError::SIG_NONSCHNORR
-                                : hasForkId ? ScriptError::MUST_USE_FORKID
-                                            : ScriptError::ILLEGAL_FORKID));
+        BOOST_CHECK_EQUAL(
+            err, !is64       ? ScriptError::SIG_NONSCHNORR
+                 : isTaproot ? ScriptError::TAPROOT_MUST_USE_BIP341_SIGHASH
+                 : hasForkId ? ScriptError::MUST_USE_FORKID
+                             : ScriptError::ILLEGAL_FORKID);
     }
 }
 
@@ -195,6 +217,7 @@ BOOST_AUTO_TEST_CASE(checksignatureencoding_test) {
         uint32_t flags = lcg.next();
 
         ScriptError err = ScriptError::OK;
+        const bool isTaproot = (flags & SCRIPT_REQUIRE_TAPROOT_SIGNATURES) != 0;
 
         // Empty sig is always validly encoded.
         BOOST_CHECK(CheckDataSignatureEncoding({}, flags, &err));
@@ -210,22 +233,26 @@ BOOST_AUTO_TEST_CASE(checksignatureencoding_test) {
 
         // We enforce low S, therefore high S sigs are rejected.
         BOOST_CHECK(!CheckDataSignatureEncoding(highSSig, flags, &err));
-        BOOST_CHECK(err == ScriptError::SIG_HIGH_S);
+        BOOST_CHECK_EQUAL(err, isTaproot
+                                   ? ScriptError::TAPROOT_MUST_USE_SCHNORR_SIGS
+                                   : ScriptError::SIG_HIGH_S);
 
         for (const valtype &nonDERSig : nonDERSigs) {
             // If we get any of the dersig flags, the non canonical dersig
             // signature fails.
-            BOOST_CHECK(
-                !CheckDataSignatureEncoding(nonDERSig, flags, &err));
-            BOOST_CHECK(err == ScriptError::SIG_DER);
+            BOOST_CHECK(!CheckDataSignatureEncoding(nonDERSig, flags, &err));
+            BOOST_CHECK_EQUAL(
+                err, isTaproot ? ScriptError::TAPROOT_MUST_USE_SCHNORR_SIGS
+                               : ScriptError::SIG_DER);
         }
 
         for (const valtype &nonDERSig : nonParsableSigs) {
             // If we get any of the dersig flags, the high S but non dersig
             // signature fails.
-            BOOST_CHECK(
-                !CheckDataSignatureEncoding(nonDERSig, flags, &err));
-            BOOST_CHECK(err == ScriptError::SIG_DER);
+            BOOST_CHECK(!CheckDataSignatureEncoding(nonDERSig, flags, &err));
+            BOOST_CHECK_EQUAL(
+                err, isTaproot ? ScriptError::TAPROOT_MUST_USE_SCHNORR_SIGS
+                               : ScriptError::SIG_DER);
         }
     }
 }
@@ -381,22 +408,28 @@ BOOST_AUTO_TEST_CASE(checkschnorr_test) {
     MMIXLinearCongruentialGenerator lcg;
     for (int i = 0; i < 4096; i++) {
         uint32_t flags = lcg.next();
+        const bool isTaproot = (flags & SCRIPT_REQUIRE_TAPROOT_SIGNATURES) != 0;
 
-        const bool hasForkId = (flags & SCRIPT_ENABLE_SIGHASH_FORKID) != 0;
+        SigHashType sigHashType = SigHashType();
+        if (isTaproot) {
+            // Prevent invalid flag combinations
+            flags |= SCRIPT_ENABLE_SIGHASH_FORKID;
+            sigHashType = sigHashType.withBIP341();
+        } else if (flags & SCRIPT_ENABLE_SIGHASH_FORKID) {
+            sigHashType = sigHashType.withForkId();
+        }
 
         ScriptError err = ScriptError::OK;
-        valtype DER65_hb = SignatureWithHashType(
-            DER64, SigHashType().withAlgorithm(hasForkId ? SIGHASH_FORKID
-                                                         : SIGHASH_LEGACY));
-        valtype Zero65_hb = SignatureWithHashType(
-            Zero64, SigHashType().withAlgorithm(hasForkId ? SIGHASH_FORKID
-                                                          : SIGHASH_LEGACY));
+        valtype DER65_hb = SignatureWithHashType(DER64, sigHashType);
+        valtype Zero65_hb = SignatureWithHashType(Zero64, sigHashType);
 
         BOOST_CHECK(CheckDataSignatureEncoding(DER64, flags, &err));
         BOOST_CHECK(CheckTransactionSignatureEncoding(DER65_hb, flags, &err));
         BOOST_CHECK(
             !CheckTransactionECDSASignatureEncoding(DER65_hb, flags, &err));
-        BOOST_CHECK(err == ScriptError::SIG_BADLENGTH);
+        BOOST_CHECK_EQUAL(err, isTaproot
+                                   ? ScriptError::TAPROOT_MUST_USE_SCHNORR_SIGS
+                                   : ScriptError::SIG_BADLENGTH);
         BOOST_CHECK(
             CheckTransactionSchnorrSignatureEncoding(DER65_hb, flags, &err));
 
@@ -404,7 +437,9 @@ BOOST_AUTO_TEST_CASE(checkschnorr_test) {
         BOOST_CHECK(CheckTransactionSignatureEncoding(Zero65_hb, flags, &err));
         BOOST_CHECK(
             !CheckTransactionECDSASignatureEncoding(Zero65_hb, flags, &err));
-        BOOST_CHECK(err == ScriptError::SIG_BADLENGTH);
+        BOOST_CHECK_EQUAL(err, isTaproot
+                                   ? ScriptError::TAPROOT_MUST_USE_SCHNORR_SIGS
+                                   : ScriptError::SIG_BADLENGTH);
         BOOST_CHECK(
             CheckTransactionSchnorrSignatureEncoding(Zero65_hb, flags, &err));
     }

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -466,9 +466,12 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, TestChain100Setup) {
 
         // This should be valid under all script flags that support our sighash
         // convention.
-        ValidateCheckInputsForAllFlags(
-            CTransaction(tx), SCRIPT_ENABLE_REPLAY_PROTECTION,
-            SCRIPT_ENABLE_SIGHASH_FORKID, true, 2);
+        // If the SCRIPT_REQUIRE_TAPROOT_SIGNATURES is set (which never occurs
+        // during script execution), the tx fails.
+        ValidateCheckInputsForAllFlags(CTransaction(tx),
+                                       SCRIPT_ENABLE_REPLAY_PROTECTION |
+                                           SCRIPT_REQUIRE_TAPROOT_SIGNATURES,
+                                       SCRIPT_ENABLE_SIGHASH_FORKID, true, 2);
 
         {
             // Try checking this valid transaction with sigchecks limiter


### PR DESCRIPTION
Ensures that signatures are Schnorr signatures (64 byte long w/o sig hash flag) and use the BIP341 sighash.

This flag is required for verifying signatures for the Taproot key spend path (spending without revealing the script).

Is is never set during script execution, only during signature verification.