### PR TITLE
Add SCRIPT_TAPROOT_KEY_SPEND_PATH script flag

### DIFF
--- a/src/script/script_error.cpp
+++ b/src/script/script_error.cpp
@@ -110,6 +110,10 @@ std::string ScriptErrorString(const ScriptError serror) {
             return "Validation resources exceeded (SigChecks)";
         case ScriptError::INVALID_OP_SCRIPTTYPE:
             return "Marker opcode OP_SCRIPTTYPE cannot be executed";
+        case ScriptError::TAPROOT_KEY_SPEND_MUST_USE_BIP341_SIGHASH:
+            return "Taproot key spend signatures must use SIGHASH_BIP341";
+        case ScriptError::TAPROOT_KEY_SPEND_MUST_USE_SCHNORR_SIG:
+            return "Taproot key spend signature must be Schnorr";
         case ScriptError::UNKNOWN:
         case ScriptError::ERROR_COUNT:
         default:

--- a/src/script/script_error.h
+++ b/src/script/script_error.h
@@ -89,6 +89,11 @@ enum class ScriptError {
        marker */
     INVALID_OP_SCRIPTTYPE,
 
+    /* Key spend path for Taproot must use BIP341 sighash */
+    TAPROOT_KEY_SPEND_MUST_USE_BIP341_SIGHASH,
+    /* Key spend path for Taproot must Schnorr signatures */
+    TAPROOT_KEY_SPEND_MUST_USE_SCHNORR_SIG,
+
     ERROR_COUNT,
 };
 

--- a/src/script/script_flags.h
+++ b/src/script/script_flags.h
@@ -11,6 +11,11 @@
 enum {
     SCRIPT_VERIFY_NONE = 0,
 
+    // Require BIP341 sighash and Schnorr signatures for key spend path
+    // (spending without revealing the script) in Taproot.
+    // Only used for checking signatures, not during script execution.
+    SCRIPT_TAPROOT_KEY_SPEND_PATH = (1U << 0),
+
     // Discourage use of NOPs reserved for upgrades (NOP1-10)
     //
     // Provided so that nodes can avoid accepting or mining transactions

--- a/src/script/sigencoding.cpp
+++ b/src/script/sigencoding.cpp
@@ -160,6 +160,11 @@ static bool IsSchnorrSig(const slicedvaltype &sig) {
 static bool CheckRawECDSASignatureEncoding(const slicedvaltype &sig,
                                            uint32_t flags,
                                            ScriptError *serror) {
+    if (flags & SCRIPT_TAPROOT_KEY_SPEND_PATH) {
+        // In Taproot key spend path, only Schnorr signatures are allowed.
+        return set_error(serror,
+                         ScriptError::TAPROOT_KEY_SPEND_MUST_USE_SCHNORR_SIG);
+    }
     if (IsSchnorrSig(sig)) {
         // In an ECDSA-only context, 64-byte signatures are forbidden.
         return set_error(serror, ScriptError::SIG_BADLENGTH);
@@ -216,6 +221,11 @@ static bool CheckSighashEncoding(const valtype &vchSig, uint32_t flags,
     }
 
     SigHashType sigHashType = GetHashType(vchSig);
+    // For Taproot key spend path, using BIP341 sighash is required
+    if ((flags & SCRIPT_TAPROOT_KEY_SPEND_PATH) && !sigHashType.hasBIP341()) {
+        return set_error(
+            serror, ScriptError::TAPROOT_KEY_SPEND_MUST_USE_BIP341_SIGHASH);
+    }
     bool usesForkId = sigHashType.hasForkId() || sigHashType.hasBIP341();
     bool forkIdEnabled = flags & SCRIPT_ENABLE_SIGHASH_FORKID;
     if (!forkIdEnabled && usesForkId) {

--- a/src/test/checkdatasig_tests.cpp
+++ b/src/test/checkdatasig_tests.cpp
@@ -140,6 +140,8 @@ BOOST_AUTO_TEST_CASE(checkdatasig_test) {
     MMIXLinearCongruentialGenerator lcg;
     for (int i = 0; i < 4096; i++) {
         uint32_t flags = lcg.next();
+        // Flag cannot occur in script execution, only in Taproot key spend
+        flags &= ~SCRIPT_TAPROOT_KEY_SPEND_PATH;
 
         // Since strict encoding is enforced, hybrid keys are invalid.
         CheckError(flags, {{}, message, pubkeyH}, script,

--- a/src/test/schnorr_tests.cpp
+++ b/src/test/schnorr_tests.cpp
@@ -92,6 +92,8 @@ BOOST_AUTO_TEST_CASE(opcodes_random_flags) {
     MMIXLinearCongruentialGenerator lcg(1234);
     for (int i = 0; i < 4096; i++) {
         uint32_t flags = lcg.next();
+        // Flag cannot occur in script execution, only in Taproot key spend
+        flags &= ~SCRIPT_TAPROOT_KEY_SPEND_PATH;
 
         const bool hasForkId = (flags & SCRIPT_ENABLE_SIGHASH_FORKID) != 0;
         const SigHashType sigHashType = SigHashType().withAlgorithm(

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -95,6 +95,10 @@ static ScriptErrorDesc script_errors[] = {
     {ScriptError::INVALID_BIT_RANGE, "BIT_RANGE"},
     {ScriptError::INVALID_NUM2BIN_SIZE, "INVALID_NUM2BIN_SIZE"},
     {ScriptError::INVALID_OP_SCRIPTTYPE, "INVALID_OP_SCRIPTTYPE"},
+    {ScriptError::TAPROOT_KEY_SPEND_MUST_USE_BIP341_SIGHASH,
+     "TAPROOT_KEY_SPEND_MUST_USE_BIP341_SIGHASH"},
+    {ScriptError::TAPROOT_KEY_SPEND_MUST_USE_SCHNORR_SIG,
+     "TAPROOT_KEY_SPEND_MUST_USE_SCHNORR_SIG"},
 };
 
 static std::string FormatScriptError(ScriptError err) {

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -466,9 +466,12 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, TestChain100Setup) {
 
         // This should be valid under all script flags that support our sighash
         // convention.
-        ValidateCheckInputsForAllFlags(
-            CTransaction(tx), SCRIPT_ENABLE_REPLAY_PROTECTION,
-            SCRIPT_ENABLE_SIGHASH_FORKID, true, 2);
+        // If the SCRIPT_TAPROOT_KEY_SPEND_PATH is set (which never occurs
+        // during script execution), the tx fails.
+        ValidateCheckInputsForAllFlags(CTransaction(tx),
+                                       SCRIPT_ENABLE_REPLAY_PROTECTION |
+                                           SCRIPT_TAPROOT_KEY_SPEND_PATH,
+                                       SCRIPT_ENABLE_SIGHASH_FORKID, true, 2);
 
         {
             // Try checking this valid transaction with sigchecks limiter


### PR DESCRIPTION
Ensures that signatures are Schnorr signatures (64 byte long + sig hash flag) and use the BIP341 sighash.

This flag is required for verifying signatures for the Taproot key spend path (spending without revealing the script).

It is never set during script execution, only during signature verification.